### PR TITLE
Improved docstrings and some type hints.

### DIFF
--- a/create_docs.sh
+++ b/create_docs.sh
@@ -5,4 +5,4 @@
 sysarch=$(uname -m)
 build_dir=$(find . -name "lib.*${sysarch}*" -type d)
 echo "Building docs from: $build_dir"
-pdoc -o 'docs' $build_dir/grib2io
+pdoc --docformat numpy -o 'docs' $build_dir/grib2io

--- a/grib2io/_grib2io.py
+++ b/grib2io/_grib2io.py
@@ -1180,12 +1180,12 @@ class _Grib2Message:
         method_options : list of ints, optional
             Interpolation options. See the NCEPLIBS-ip documentation for
             more information on how these are used.
-
-        **`drtn : int, optional
-            Data Representation Template to be used for the returned interpolated
-            GRIB2 message. When `None`, the data representation template of the
-            source GRIB2 message is used. Once again, it is the user's responsibility
-            to properly set the Data Representation Template attributes.
+        drtn
+            Data Representation Template to be used for the returned
+            interpolated GRIB2 message. When `None`, the data representation
+            template of the source GRIB2 message is used. Once again, it is the
+            user's responsibility to properly set the Data Representation
+            Template attributes.
 
         Returns
         -------
@@ -1193,7 +1193,7 @@ class _Grib2Message:
             If interpolating to a grid, a new Grib2Message object is returned.
             The GRIB2 metadata of the new Grib2Message object is identical to
             the input except where required to be different because of the new
-            grid specs.
+            grid specs and possibly a new data representation template.
 
             If interpolating to station points, the interpolated data values are
             returned as a numpy.ndarray.

--- a/grib2io/tables/__init__.py
+++ b/grib2io/tables/__init__.py
@@ -2,7 +2,7 @@
 
 from functools import lru_cache
 
-from typing import Optional, Union
+from typing import Optional, Union, List
 from numpy.typing import ArrayLike
 
 from .section0 import *
@@ -147,7 +147,7 @@ def get_shortnames(
     parmcat: Optional[Union[int, str]] = None,
     parmnum: Optional[Union[int, str]] = None,
     isNDFD: bool = False,
-) -> list[str]:
+) -> List[str]:
     """
     Return a list of variable shortNames.
 

--- a/grib2io/tables/__init__.py
+++ b/grib2io/tables/__init__.py
@@ -1,8 +1,9 @@
-"""
-Functions for retreiving data from NCEP GRIB2 Tables.
-"""
-#from functools import cache # USE WHEN Python 3.9+ only
+"""Functions for retrieving data from NCEP GRIB2 Tables."""
+
 from functools import lru_cache
+
+from typing import Optional, Union
+from numpy.typing import ArrayLike
 
 from .section0 import *
 from .section1 import *
@@ -14,22 +15,24 @@ from .originating_centers import *
 
 GRIB2_DISCIPLINES = [0, 1, 2, 3, 4, 10, 20]
 
-def get_table(table, expand=False):
+def get_table(table: str, expand: bool=False) -> dict:
     """
     Return GRIB2 code table as a dictionary.
 
     Parameters
     ----------
-    **`table : str`**
-        Code table number (e.g. '1.0'). NOTE: Code table '4.1' requires a 3rd value
-        representing the product discipline (e.g. '4.1.0').
+    table
+        Code table number (e.g. '1.0').
 
-    **`expand : bool, optional`**
-        If `True`, expand output dictionary where keys are a range.
+        NOTE: Code table '4.1' requires a 3rd value representing the product
+        discipline (e.g. '4.1.0').
+    expand
+        If `True`, expand output dictionary wherever keys are a range.
 
     Returns
     -------
-    Table as a **`dict`**.
+    get_table
+        GRIB2 code table as a dictionary.
     """
     if len(table) == 3 and table == '4.1':
         raise Exception('GRIB2 Code Table 4.1 requires a 3rd value representing the discipline.')
@@ -52,24 +55,27 @@ def get_table(table, expand=False):
         return {}
 
 
-def get_value_from_table(value, table, expand=False):
+def get_value_from_table(
+    value: Union[int, str],
+    table: str,
+    expand: bool = False,
+) -> Optional[Union[float, int]]:
     """
     Return the definition given a GRIB2 code table.
 
     Parameters
     ----------
-    **`value : int or str`**
+    value
         Code table value.
-
-    **`table : str`**
+    table
         Code table number.
-
-    **`expand : bool, optional`**
+    expand
         If `True`, expand output dictionary where keys are a range.
 
     Returns
     -------
-    Table value or `None` if not found.
+    get_value_from_table
+        Table value or `None` if not found.
     """
     try:
         tbl = get_table(table,expand=expand)
@@ -84,34 +90,39 @@ def get_value_from_table(value, table, expand=False):
         return None
 
 
-def get_varinfo_from_table(discipline,parmcat,parmnum,isNDFD=False):
+def get_varinfo_from_table(
+    discipline: Union[int, str],
+    parmcat: Union[int, str],
+    parmnum: Union[int, str],
+    isNDFD: bool = False,
+):
     """
-    Return the GRIB2 variable information given values of `discipline`,
-    `parmcat`, and `parmnum`. NOTE: This functions allows for all arguments
-    to be converted to a string type if arguments are integer.
+    Return the GRIB2 variable information.
+
+    NOTE: This functions allows for all arguments to be converted to a string
+    type if arguments are integer.
 
     Parameters
     ----------
-    **`discipline : int or str`**
+    discipline
         Discipline code value of a GRIB2 message.
-
-    **`parmcat : int or str`**
+    parmcat
         Parameter Category value of a GRIB2 message.
-
-    **`parmnum : int or str`**
+    parmnum
         Parameter Number value of a GRIB2 message.
-
-    **`isNDFD : bool, optional`**
-        If `True`, signals function to try to get variable information from 
-        the supplemental NDFD tables.
+    isNDFD: optional
+        If `True`, signals function to try to get variable information from the
+        supplemental NDFD tables.
 
     Returns
     -------
-    **`list`** containing variable information. "Unknown" is given for item of
-    information if variable is not found.
-        - list[0] = full name
-        - list[1] = units
-        - list[2] = short name (abbreviated name)
+    full_name
+        Full name of the GRIB2 variable. "Unknown" if variable is not found.
+    units
+        Units of the GRIB2 variable. "Unknown" if variable is not found.
+    shortName
+        Abbreviated name of the GRIB2 variable. "Unknown" if variable is not
+        found.
     """
     if isNDFD:
         try:
@@ -121,7 +132,6 @@ def get_varinfo_from_table(discipline,parmcat,parmnum,isNDFD=False):
             return locals()[tblname][str(parmnum)]
         except(ImportError,KeyError):
             pass
-            #return ['Unknown','Unknown','Unknown']
     try:
         tblname = f'table_4_2_{discipline}_{parmcat}'
         modname = f'.section4_discipline{discipline}'
@@ -131,28 +141,35 @@ def get_varinfo_from_table(discipline,parmcat,parmnum,isNDFD=False):
         return ['Unknown','Unknown','Unknown']
 
 
-#@cache# USE WHEN Python 3.9+ only
 @lru_cache(maxsize=None)
-def get_shortnames(discipline=None, parmcat=None, parmnum=None, isNDFD=False):
+def get_shortnames(
+    discipline: Optional[Union[int, str]] = None,
+    parmcat: Optional[Union[int, str]] = None,
+    parmnum: Optional[Union[int, str]] = None,
+    isNDFD: bool = False,
+) -> list[str]:
     """
-    Returns a list of variable shortNames given GRIB2 discipline, parameter
-    category, and parameter number.  If all 3 args are None, then shortNames
-    from all disciplines, parameter categories, and numbers will be returned.
+    Return a list of variable shortNames.
+
+    If all 3 args are None, then shortNames from all disciplines, parameter
+    categories, and numbers will be returned.
 
     Parameters
     ----------
-    **`discipline : int`**
+    discipline
         GRIB2 discipline code value.
-
-    **`parmcat : int`**
+    parmcat
         GRIB2 parameter category value.
-
-    **`parmnum : int or str`**
+    parmnum
         Parameter Number value of a GRIB2 message.
+    isNDFD: optional
+        If `True`, signals function to try to get variable information from the
+        supplemental NDFD tables.
 
     Returns
     -------
-    **`list`** of GRIB2 shortNames.
+    get_shortnames
+        list of GRIB2 shortNames.
     """
     shortnames = list()
     if discipline is None:
@@ -184,22 +201,24 @@ def get_shortnames(discipline=None, parmcat=None, parmnum=None, isNDFD=False):
     return shortnames
 
 
-#@cache# USE WHEN Python 3.9+ only
 @lru_cache(maxsize=None)
-def get_metadata_from_shortname(shortname):
+def get_metadata_from_shortname(shortname: str):
     """
     Provide GRIB2 variable metadata attributes given a GRIB2 shortName.
 
     Parameters
     ----------
-    **`shortname : str`**
+    shortname
         GRIB2 variable shortName.
 
     Returns
     -------
-    **`list`** of dictionary items where each dictionary items contains the variable
-    metadata key:value pairs. **NOTE:** Some variable shortNames will exist in multiple
-    parameter category/number tables according to the GRIB2 discipline.
+    get_metadata_from_shortname
+        list of dictionary items where each dictionary item contains the
+        variable metadata key:value pairs.
+
+        NOTE: Some variable shortNames will exist in multiple parameter
+        category/number tables according to the GRIB2 discipline.
     """
     metadata = []
     for d in GRIB2_DISCIPLINES:
@@ -213,27 +232,29 @@ def get_metadata_from_shortname(shortname):
     return metadata
 
 
-def get_wgrib2_level_string(pdtn, pdt):
+def get_wgrib2_level_string(pdtn: int, pdt: ArrayLike) -> str:
     """
-    Return a string that describes the level or layer of the GRIB2 message. The
-    format and language of the string is an exact replica of how wgrib2 produces
-    the level/layer string in its inventory output.
+    Return a string that describes the level or layer of the GRIB2 message.
 
-    Contents of wgrib2 source, [Level.c](https://github.com/NOAA-EMC/NCEPLIBS-wgrib2/blob/develop/wgrib2/Level.c),
+    The format and language of the string is an exact replica of how wgrib2
+    produces the level/layer string in its inventory output.
+
+    Contents of wgrib2 source,
+    [Level.c](https://github.com/NOAA-EMC/NCEPLIBS-wgrib2/blob/develop/wgrib2/Level.c),
     were converted into a Python dictionary and stored in grib2io as table
     'wgrib2_level_string'.
 
     Parameters
     ----------
-    **`pdtn :  int`**
+    pdtn
         GRIB2 Product Definition Template Number
-
-    **`pdt : list or array_like`**
+    pdt
         Sequence containing GRIB2 Product Definition Template (Section 4).
 
     Returns
     -------
-    wgrib2-formatted level/layer string.
+    get_wgrib2_level_string
+        wgrib2-formatted level/layer string.
     """
     lvlstr = ''
     if pdtn == 32:

--- a/grib2io/templates.py
+++ b/grib2io/templates.py
@@ -1,10 +1,8 @@
-"""
-GRIB2 section templates classes and metadata descriptor classes
-"""
+"""GRIB2 section templates classes and metadata descriptor classes."""
 from dataclasses import dataclass, field
 from collections import defaultdict
 import datetime
-import numpy as np
+from typing import Union
 
 from . import tables
 from . import utils
@@ -26,18 +24,18 @@ _section_attrs = {0:['discipline'],
 
 class Grib2Metadata:
     """
-    Class to hold GRIB2 metadata both as numeric code value as stored in
-    GRIB2 and its plain langauge definition.
+    Class to hold GRIB2 metadata.
+
+    Stores both numeric code value as stored in GRIB2 and its plain language
+    definition.
 
     Attributes
     ----------
-    **`value : int`**
+    value : int
         GRIB2 metadata integer code value.
-
-    **`table : str, optional`**
+    table : str, optional
         GRIB2 table to lookup the `value`. Default is None.
-
-    **`definition : str`**
+    definition : str
         Plain language description of numeric metadata.
     """
     __slots__ = ('value','table')
@@ -47,7 +45,9 @@ class Grib2Metadata:
     def __call__(self):
         return self.value
     def __hash__(self):
-        return hash(self.value)   # AS- added hash() to self.value as pandas was raising error about some non integer returns from hash method
+        # AS- added hash() to self.value as pandas was raising error about some
+        # non integer returns from hash method
+        return hash(self.value)
     def __repr__(self):
         return f"{self.__class__.__name__}({self.value}, table = '{self.table}')"
     def __str__(self):
@@ -72,9 +72,7 @@ class Grib2Metadata:
     def definition(self):
         return tables.get_value_from_table(self.value,self.table)
     def show_table(self):
-        """
-        Provide the table related to this metadata.
-        """
+        """Provide the table related to this metadata."""
         return tables.get_table(self.table)
 
 # ----------------------------------------------------------------------------------------
@@ -836,18 +834,19 @@ _gdt_by_gdtn = {0: GridDefinitionTemplate0,
     32769: GridDefinitionTemplate32769,
     }
 
-def gdt_class_by_gdtn(gdtn):
+def gdt_class_by_gdtn(gdtn: int):
     """
     Provides a Grid Definition Template class via the template number
 
     Parameters
     ----------
-    **`gdtn : int`**
+    gdtn
         Grid definition template number.
 
     Returns
     -------
-    Grid definition template class object (not an instance).
+    gdt_class_by_gdtn
+        Grid definition template class object (not an instance).
     """
     return _gdt_by_gdtn[gdtn]
 
@@ -887,30 +886,32 @@ class ParameterNumber:
 
 class VarInfo:
     """
-    Variable Information.  These are the metadata returned for a specific variable according
-    to discipline, parameter category, and parameter number.
-    """ 
+    Variable Information.
+
+    These are the metadata returned for a specific variable according to
+    discipline, parameter category, and parameter number.
+    """
     def __get__(self, obj, objtype=None):
         return tables.get_varinfo_from_table(obj.section0[2],*obj.section4[2:4],isNDFD=obj._isNDFD)
     def __set__(self, obj, value):
         raise RuntimeError
 
 class FullName:
-    """Full name of the Variable"""
+    """Full name of the Variable."""
     def __get__(self, obj, objtype=None):
         return tables.get_varinfo_from_table(obj.section0[2],*obj.section4[2:4],isNDFD=obj._isNDFD)[0]
     def __set__(self, obj, value):
         raise RuntimeError
 
 class Units:
-    """Units of the Variable"""
+    """Units of the Variable."""
     def __get__(self, obj, objtype=None):
         return tables.get_varinfo_from_table(obj.section0[2],*obj.section4[2:4],isNDFD=obj._isNDFD)[1]
     def __set__(self, obj, value):
         raise RuntimeError
 
 class ShortName:
-    """ Short name of the variable (i.e. the variable abbreviation)"""
+    """ Short name of the variable (i.e. the variable abbreviation)."""
     def __get__(self, obj, objtype=None):
         return tables.get_varinfo_from_table(obj.section0[2],*obj.section4[2:4],isNDFD=obj._isNDFD)[2]
     def __set__(self, obj, value):
@@ -944,7 +945,7 @@ class GeneratingProcess:
         obj.section4[self._key[obj.pdtn]+2] = value
 
 class HoursAfterDataCutoff:
-    """Hours of observational data cutoff after reference time"""
+    """Hours of observational data cutoff after reference time."""
     _key = defaultdict(lambda: 5, {48:16})
     def __get__(self, obj, objtype=None):
         return obj.section4[self._key[obj.pdtn]+2]
@@ -952,7 +953,7 @@ class HoursAfterDataCutoff:
         obj.section4[self._key[obj.pdtn]+2] = value
 
 class MinutesAfterDataCutoff:
-    """Minutes of observational data cutoff after reference time"""
+    """Minutes of observational data cutoff after reference time."""
     _key = defaultdict(lambda: 6, {48:17})
     def __get__(self, obj, objtype=None):
         return obj.section4[self._key[obj.pdtn]+2]
@@ -969,7 +970,7 @@ class UnitOfForecastTime:
         obj.section4[self._key[obj.pdtn]+2] = value
 
 class ValueOfForecastTime:
-    """Value of forecast time in units defined by `UnitofForecastTime`"""
+    """Value of forecast time in units defined by `UnitofForecastTime`."""
     _key = defaultdict(lambda: 8, {48:19})
     def __get__(self, obj, objtype=None):
         return obj.section4[self._key[obj.pdtn]+2]
@@ -996,7 +997,7 @@ class FixedSfc1Info:
         raise NotImplementedError
 
 class FixedSfc2Info:
-    """Information of the seconds fixed surface via [table 4.5](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-5.shtml)"""
+    """Information of the second fixed surface via [table 4.5](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-5.shtml)"""
     _key = defaultdict(lambda: 12, {48:23})
     #_key = {0:12, 1:12, 2:12, 5:12, 6:12, 8:12, 9:12, 10:12, 11:12, 12:12, 15:12, 48:23}
     def __get__(self, obj, objtype=None):
@@ -1908,18 +1909,19 @@ _pdt_by_pdtn = {
     48: ProductDefinitionTemplate48,
     }
 
-def pdt_class_by_pdtn(pdtn):
+def pdt_class_by_pdtn(pdtn: int):
     """
-    Provides a Product Definition Template class via the template number
+    Provide a Product Definition Template class via the template number.
 
     Parameters
     ----------
-    **`pdtn : int`**
+    pdtn
         Product definition template number.
 
     Returns
     -------
-    Product definition template class object (not an instance).
+    pdt_class_by_pdtn
+        Product definition template class object (not an instance).
     """
     return _pdt_by_pdtn[pdtn]
 
@@ -2163,8 +2165,8 @@ class DataRepresentationTemplate2:
     nBitsPacking: int = field(init=False, repr=False, default=NBitsPacking())
     groupSplittingMethod: Grib2Metadata = field(init=False, repr=False, default=GroupSplittingMethod())
     typeOfMissingValueManagement: Grib2Metadata = field(init=False, repr=False, default=TypeOfMissingValueManagement())
-    priMissingValue: [float, int] = field(init=False, repr=False, default=PriMissingValue())
-    secMissingValue: [float, int] = field(init=False, repr=False, default=SecMissingValue())
+    priMissingValue: Union[float, int] = field(init=False, repr=False, default=PriMissingValue())
+    secMissingValue: Union[float, int] = field(init=False, repr=False, default=SecMissingValue())
     nGroups: int = field(init=False, repr=False, default=NGroups())
     refGroupWidth: int = field(init=False, repr=False, default=RefGroupWidth())
     nBitsGroupWidth: int = field(init=False, repr=False, default=NBitsGroupWidth())
@@ -2189,8 +2191,8 @@ class DataRepresentationTemplate3:
     nBitsPacking: int = field(init=False, repr=False, default=NBitsPacking())
     groupSplittingMethod: Grib2Metadata = field(init=False, repr=False, default=GroupSplittingMethod())
     typeOfMissingValueManagement: Grib2Metadata = field(init=False, repr=False, default=TypeOfMissingValueManagement())
-    priMissingValue: [float, int] = field(init=False, repr=False, default=PriMissingValue())
-    secMissingValue: [float, int] = field(init=False, repr=False, default=SecMissingValue())
+    priMissingValue: Union[float, int] = field(init=False, repr=False, default=PriMissingValue())
+    secMissingValue: Union[float, int] = field(init=False, repr=False, default=SecMissingValue())
     nGroups: int = field(init=False, repr=False, default=NGroups())
     refGroupWidth: int = field(init=False, repr=False, default=RefGroupWidth())
     nBitsGroupWidth: int = field(init=False, repr=False, default=NBitsGroupWidth())
@@ -2294,17 +2296,18 @@ _drt_by_drtn = {
     50: DataRepresentationTemplate50,
     }
 
-def drt_class_by_drtn(drtn):
+def drt_class_by_drtn(drtn: int):
     """
-    Provides a Data Representation Template class via the template number
+    Provide a Data Representation Template class via the template number.
 
     Parameters
     ----------
-    **`drtn : int`**
+    drtn
         Data Representation template number.
 
     Returns
     -------
-    Data Representation template class object (not an instance).
+    drt_class_by_drtn
+        Data Representation template class object (not an instance).
     """
     return _drt_by_drtn[drtn]

--- a/grib2io/utils/__init__.py
+++ b/grib2io/utils/__init__.py
@@ -4,15 +4,15 @@ of GRIB2 Messages.
 """
 
 import datetime
-import numpy as np
 import struct
-from typing import Union
+from typing import Union, Type
 
+import numpy as np
 from numpy.typing import ArrayLike
 
 from .. import tables
 
-def int2bin(i: int, nbits: int=8, output: Union[type[str], type[list]]=str):
+def int2bin(i: int, nbits: int=8, output: Union[Type[str], Type[list]]=str):
     """
     Convert integer to binary string or list
 

--- a/grib2io/utils/__init__.py
+++ b/grib2io/utils/__init__.py
@@ -5,14 +5,14 @@ of GRIB2 Messages.
 
 import datetime
 import struct
-from typing import Union, Type
+from typing import Union, Type, Dict, List
 
 import numpy as np
 from numpy.typing import ArrayLike
 
 from .. import tables
 
-def int2bin(i: int, nbits: int=8, output: Union[Type[str], Type[list]]=str):
+def int2bin(i: int, nbits: int=8, output: Union[Type[str], Type[List]]=str):
     """
     Convert integer to binary string or list
 
@@ -139,7 +139,7 @@ def get_duration(pdtn: int, pdt: ArrayLike) -> datetime.timedelta:
         return None
 
 
-def decode_wx_strings(lus: bytes) -> dict[int, str]:
+def decode_wx_strings(lus: bytes) -> Dict[int, str]:
     """
     Decode GRIB2 Local Use Section to obtain NDFD/MDL Weather Strings.
 

--- a/grib2io/utils/__init__.py
+++ b/grib2io/utils/__init__.py
@@ -6,27 +6,34 @@ of GRIB2 Messages.
 import datetime
 import numpy as np
 import struct
+from typing import Union
+
+from numpy.typing import ArrayLike
 
 from .. import tables
 
-def int2bin(i, nbits=8, output=str):
+def int2bin(i: int, nbits: int=8, output: Union[type[str], type[list]]=str):
     """
     Convert integer to binary string or list
 
+    The struct module unpack using ">i" will unpack a 32-bit integer from a
+    binary string.
+
     Parameters
     ----------
-    **`i : int`**
+    i
         Integer value to convert to binary representation.
-
-    **`nbits : int, optional`**
-        Number of bits to return.  Valid values are 8 [DEFAULT], 16, 32, and 64.
-
-    **`output : type`**
+    nbits : default=8
+        Number of bits to return.  Valid values are 8 [DEFAULT], 16, 32, and
+        64.
+    output : default=str
         Return data as `str` [DEFAULT] or `list` (list of ints).
 
     Returns
     -------
-    `str` or `list` (list of ints) of binary representation of the integer value.
+    int2bin
+        `str` or `list` (list of ints) of binary representation of the integer
+        value.
     """
     i = int(i) if not isinstance(i,int) else i
     assert nbits in [8,16,32,64]
@@ -39,16 +46,17 @@ def int2bin(i, nbits=8, output=str):
 
 def ieee_float_to_int(f):
     """
-    Convert an IEEE 32-bit float to a 32-bit integer.
+    Convert an IEEE 754 32-bit float to a 32-bit integer.
 
     Parameters
     ----------
-    **`f : float`**
+    f : float
         Floating-point value.
 
     Returns
     -------
-    `numpy.int32` representation of an IEEE 32-bit float.
+    ieee_float_to_int
+        `numpy.int32` representation of an IEEE 32-bit float.
     """
     i = struct.unpack('>i',struct.pack('>f',np.float32(f)))[0]
     return np.int32(i)
@@ -60,37 +68,38 @@ def ieee_int_to_float(i):
 
     Parameters
     ----------
-    **`i : int`**
+    i : int
         Integer value.
 
     Returns
     -------
-    `numpy.float32` representation of a 32-bit int.
+    ieee_int_to_float
+        `numpy.float32` representation of a 32-bit int.
     """
     f = struct.unpack('>f',struct.pack('>i',np.int32(i)))[0]
     return np.float32(f)
 
 
-def get_leadtime(idsec, pdtn, pdt):
+def get_leadtime(idsec: ArrayLike, pdtn: int, pdt: ArrayLike) -> datetime.timedelta:
     """
-    Computes lead time as a datetime.timedelta object using information from
-    GRIB2 Identification Section (Section 1), Product Definition Template
-    Number, and Product Definition Template (Section 4).
+    Compute lead time as a datetime.timedelta object.
+
+    Using information from GRIB2 Identification Section (Section 1), Product
+    Definition Template Number, and Product Definition Template (Section 4).
 
     Parameters
     ----------
-    **`idsec : list or array_like`**
+    idsec
         Seqeunce containing GRIB2 Identification Section (Section 1).
-
-    **`pdtn : int`**
+    pdtn
         GRIB2 Product Definition Template Number
-
-    **`pdt : list or array_like`**
+    pdt
         Seqeunce containing GRIB2 Product Definition Template (Section 4).
 
     Returns
     -------
-    **`datetime.timedelta`** object representing the lead time of the GRIB2 message.
+    leadTime
+        datetime.timedelta object representing the lead time of the GRIB2 message.
     """
     _key = {8:slice(15,21), 9:slice(22,28), 10:slice(16,22), 11:slice(18,24), 12:slice(17,23)}
     refdate = datetime.datetime(*idsec[5:11])
@@ -103,22 +112,25 @@ def get_leadtime(idsec, pdtn, pdt):
             return datetime.timedelta(hours=pdt[8]*(tables.get_value_from_table(pdt[7],'scale_time_hours')))
 
 
-def get_duration(pdtn, pdt):
+def get_duration(pdtn: int, pdt: ArrayLike) -> datetime.timedelta:
     """
-    Computes a time duration as a datetime.timedelta using information from
-    Product Definition Template Number, and Product Definition Template (Section 4).
+    Compute a time duration as a datetime.timedelta.
+
+    Uses information from Product Definition Template Number, and Product
+    Definition Template (Section 4).
 
     Parameters
     ----------
-    **`pdtn : int`**
+    pdtn
         GRIB2 Product Definition Template Number
-
-    **`pdt : list or array_like`**
+    pdt
         Sequence containing GRIB2 Product Definition Template (Section 4).
 
     Returns
     -------
-    **`datetime.timedelta`** object representing the time duration of the GRIB2 message.
+    get_duration
+        datetime.timedelta object representing the time duration of the GRIB2
+        message.
     """
     _key = {8:25, 9:32, 10:26, 11:28, 12:27}
     try:
@@ -127,21 +139,24 @@ def get_duration(pdtn, pdt):
         return None
 
 
-def decode_wx_strings(lus):
+def decode_wx_strings(lus: bytes) -> dict[int, str]:
     """
-    Decode GRIB2 Local Use Section to obtain NDFD/MDL Weather Strings.  The
-    decode procedure is defined [here](https://vlab.noaa.gov/web/mdl/nbm-gmos-grib2-wx-info).
+    Decode GRIB2 Local Use Section to obtain NDFD/MDL Weather Strings.
+
+    The decode procedure is defined
+    [here](https://vlab.noaa.gov/web/mdl/nbm-gmos-grib2-wx-info).
 
     Parameters
     ----------
-    **`lus : bytes`**
+    lus
         GRIB2 Local Use Section containing NDFD weather strings.
 
     Returns
     -------
-    **`dict`** of NDFD/MDL weather strings. Keys are an integer value that represent 
-    the sequential order of the key in the packed local use section and the value is 
-    the weather key.
+    decode_wx_strings
+        Dict of NDFD/MDL weather strings. Keys are an integer value that
+        represent the sequential order of the key in the packed local use
+        section and the value is the weather key.
     """
     assert lus[0] == 1
     # Unpack information related to the simple packing method
@@ -175,32 +190,37 @@ def decode_wx_strings(lus):
     return {n:k for n,k in enumerate(list(filter(None,wxstring.split('\0'))))}
 
 
-def get_wgrib2_prob_string(probtype,sfacl,svall,sfacu,svalu):
+def get_wgrib2_prob_string(
+    probtype: int,
+    sfacl: int,
+    svall: int,
+    sfacu: int,
+    svalu: int,
+) -> str:
     """
-    Return a wgrib2-formatted string explaining probabilistic
-    threshold informaiton.  Logic from wgrib2 source, [Prob.c](https://github.com/NOAA-EMC/NCEPLIBS-wgrib2/blob/develop/wgrib2/Prob.c),
+    Return a wgrib2-styled string of probabilistic threshold information.
+
+    Logic from wgrib2 source,
+    [Prob.c](https://github.com/NOAA-EMC/NCEPLIBS-wgrib2/blob/develop/wgrib2/Prob.c),
     is replicated here.
 
     Parameters
     ----------
-    **`probtype : int`**
+    probtype
         Type of probability (Code Table 4.9).
-
-    **`sfacl : int`**
+    sfacl
         Scale factor of lower limit.
-
-    **`svall : int`**
+    svall
         Scaled value of lower limit.
-
-    **`sfacu : int`**
+    sfacu
         Scale factor of upper limit.
-
-    **`svalu : int`**
+    svalu
         Scaled value of upper limit.
 
     Returns
     -------
-    wgrib2-formatted string of probability threshold.
+    get_wgrib2_prob_string
+        wgrib2-formatted string of probability threshold.
     """
     probstr = ''
     if sfacl == -127: sfacl = 0

--- a/grib2io/utils/arakawa_rotated_grid.py
+++ b/grib2io/utils/arakawa_rotated_grid.py
@@ -15,28 +15,27 @@ from . import rotated_grid
 DEG2RAD = rotated_grid.DEG2RAD
 RAD2DEG = rotated_grid.RAD2DEG
 
-def ll2rot(latin, lonin, latpole, lonpole):
+def ll2rot(latin: float, lonin: float, latpole: float, lonpole: float) -> tuple[float, float]:
     """
     Rotate a latitude/longitude pair.
 
     Parameters
     ----------
-    **`latin`**: `float`
-        Latitudes in units of degrees.
-
-    **`lonin`**: `float`
-        Longitudes in units of degrees.
-
-    **`latpole`**: `float`
+    latin
+        Unrotated latitude in units of degrees.
+    lonin
+        Unrotated longitude in units of degrees.
+    latpole
         Latitude of Pole.
-
-    **`lonpole`**: `float`
+    lonpole
         Longitude of Pole.
 
     Returns
     -------
-    **`tlat, tlons`**
-        Returns two floats of rotated latitude and longitude in units of degrees.
+    tlat
+        Rotated latitude in units of degrees.
+    tlons
+        Rotated longitude in units of degrees.
     """
     tlon = lonin - lonpole
 
@@ -70,28 +69,27 @@ def ll2rot(latin, lonin, latpole, lonpole):
     return tlat, tlon
 
 
-def rot2ll(latin, lonin, latpole, lonpole):
+def rot2ll(latin: float, lonin: float, latpole: float, lonpole: float) -> tuple[float, float]:
     """
     Unrotate a latitude/longitude pair.
 
     Parameters
     ----------
-    **`latin`**: `float`
-        Latitudes in units of degrees.
-
-    **`lonin`**: `float`
-        Longitudes in units of degrees.
-
-    **`latpole`**: `float`
+    latin
+        Rotated latitude in units of degrees.
+    lonin
+        Rotated longitude in units of degrees.
+    latpole
         Latitude of Pole.
-
-    **`lonpole`**: `float`
+    lonpole
         Longitude of Pole.
 
     Returns
     -------
-    **`tlat, tlons`**
-        Returns two floats of unrotated latitude and longitude in units of degrees.
+    tlat
+        Unrotated latitude in units of degrees.
+    tlons
+        Unrotated longitude in units of degrees.
     """
     tlon = lonin
 
@@ -116,43 +114,47 @@ def rot2ll(latin, lonin, latpole, lonpole):
         tlon = 90.0
     else:
         tlon = -90.0
-    
+
     # Remove the longitude rotation
     tlon += lonpole
     if tlon < 0:
         tlon += 360.0
     if tlon > 360:
         tlon -= 360.0
-    
+
     return tlat, tlon
 
 
-def vector_rotation_angles(tlat, tlon, clat, losp, xlat):
+def vector_rotation_angles(
+    tlat: float,
+    tlon: float,
+    clat: float,
+    losp: float,
+    xlat: float,
+) -> float:
     """
-    Generate a rotation angle value that can be applied to a vector quantity to
-    make it Earth-oriented.
+    Generate a rotation angle value.
+
+    The rotation angle value can be applied to a vector quantity to make it
+    Earth-oriented.
 
     Parameters
     ----------
-    **`tlat`**: `float`
+    tlat
         True latitude in units of degrees.
-
-    **tlon`**: `float`
+    tlon
         True longitude in units of degrees..
-
-    **`clat`**: `float`
+    clat
         Latitude of center grid point in units of degrees.
-
-    **`losp`**: `float`
+    losp
         Longitude of the southern pole in units of degrees.
-
-    **`xlat`**: `float`
+    xlat
         Latitude of the rotated grid in units of degrees.
 
     Returns
     -------
-    **`rot : float`**
-        Rotation angle in units of radians. 
+    rot
+        Rotation angle in units of radians.
     """
     slon = math.sin((tlon-losp)*DEG2RAD)
     cgridlat = math.cos(xlat*DEG2RAD)

--- a/grib2io/utils/gauss_grid.py
+++ b/grib2io/utils/gauss_grid.py
@@ -28,18 +28,19 @@ def __single_arg_fast_cache(func):
 
 
 @__single_arg_fast_cache
-def gaussian_latitudes(nlat):
+def gaussian_latitudes(nlat: int):
     """
     Construct latitudes for a Gaussian grid.
 
     Parameters
     ----------
-    **`nlat : int`**
+    nlat
         The number of latitudes in the Gaussian grid.
 
     Returns
     -------
-    `numpy.ndarray` of latitudes (in degrees) with a length of `nlat`.
+    latitudes
+        `numpy.ndarray` of latitudes (in degrees) with a length of `nlat`.
     """
     if abs(int(nlat)) != nlat:
         raise ValueError('nlat must be a non-negative integer')

--- a/grib2io/utils/rotated_grid.py
+++ b/grib2io/utils/rotated_grid.py
@@ -1,42 +1,47 @@
-"""
-Tools for working with Rotated Lat/Lon Grids.
-"""
+"""Tools for working with Rotated Lat/Lon Grids."""
 
 import numpy as np
+from numpy.typing import NDArray
 
 RAD2DEG = 57.29577951308232087684
 DEG2RAD = 0.01745329251994329576
 
-def rotate(latin, lonin, aor, splat, splon):
+def rotate(
+    latin: NDArray[np.float32],
+    lonin: NDArray[np.float32],
+    aor: NDArray[np.float32],
+    splat: NDArray[np.float32],
+    splon: NDArray[np.float32],
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
     """
-    Perform grid rotation. This function is adapted from ECMWF's ecCodes library
-    void function, rotate().
+    Perform grid rotation.
+
+    This function is adapted from ECMWF's ecCodes library void function,
+    rotate().
 
     https://github.com/ecmwf/eccodes/blob/develop/src/grib_geography.cc
 
     Parameters
     ----------
-
-    **`latin : float or array_like`**
+    latin
         Latitudes in units of degrees.
-
-    **`lonin : float or array_like`**
+    lonin
         Longitudes in units of degrees.
-
-    **`aor : float`**
+    aor
         Angle of rotation as defined in GRIB2 GDTN 4.1.
-
-    **`splat : float`**
+    splat
         Latitude of South Pole as defined in GRIB2 GDTN 4.1.
-
-    **`splon : float`**
+    splon
         Longitude of South Pole as defined in GRIB2 GDTN 4.1.
 
     Returns
     -------
-    **`lats, lons : numpy.ndarray`**
-        `numpy.ndarrays` with `dtype=numpy.float32` of grid latitudes and
-        longitudes in units of degrees.
+    lats
+        `numpy.ndarrays` with `dtype=numpy.float32` of grid latitudes in units
+        of degrees.
+    lons
+        `numpy.ndarrays` with `dtype=numpy.float32` of grid longitudes in units
+        of degrees.
     """
     zsycen = np.sin(DEG2RAD * (splat + 90.))
     zcycen = np.cos(DEG2RAD * (splat + 90.))
@@ -65,35 +70,42 @@ def rotate(latin, lonin, aor, splat, splon):
     return pyrot, pxrot
 
 
-def unrotate(latin, lonin, aor, splat, splon):
+def unrotate(
+    latin: NDArray[np.float32],
+    lonin: NDArray[np.float32],
+    aor: NDArray[np.float32],
+    splat: NDArray[np.float32],
+    splon: NDArray[np.float32],
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
     """
-    Perform grid un-rotation. This function is adapted from ECMWF's ecCodes library
-    void function, unrotate().
+    Perform grid un-rotation.
+
+    This function is adapted from ECMWF's ecCodes library void function,
+    unrotate().
 
     https://github.com/ecmwf/eccodes/blob/develop/src/grib_geography.cc
 
     Parameters
     ----------
-    **`latin : float or array_like`**
+    latin
         Latitudes in units of degrees.
-
-    **`lonin : float or array_like`**
+    lonin
         Longitudes in units of degrees.
-
-    **`aor : float`**
+    aor
         Angle of rotation as defined in GRIB2 GDTN 4.1.
-
-    **`splat : float`**
+    splat
         Latitude of South Pole as defined in GRIB2 GDTN 4.1.
-
-    **`splon : float`**
+    splon
         Longitude of South Pole as defined in GRIB2 GDTN 4.1.
 
     Returns
     -------
-    **`lats, lons : numpy.ndarray`**
-        `numpy.ndarrays` with `dtype=numpy.float32` of grid latitudes and
-        longitudes in units of degrees.
+    lats
+        `numpy.ndarrays` with `dtype=numpy.float32` of grid latitudes in units
+        of degrees.
+    lons
+        `numpy.ndarrays` with `dtype=numpy.float32` of grid longitudes in units
+        of degrees.
     """
     lon_x = lonin
     lat_y = latin


### PR DESCRIPTION
* Removed markdown markup in docstrings in favor of using "--docformat numpy" for the pdoc command in create_docs.sh.
* Used numpy format for the "Return" sections to be properly rendered by "pdoc --docformat numpy ...".
* Removed blank lines between parameters in the "Parameters" section.
* Added missing docstrings.
* Minor improvements to type hints:
  + np.array to NDArray,
  + Optional[] wherever argument could be None,
  + Addition of Union where needed.