### PR TITLE
Change to match shapes for setting leadTime attrs.

### DIFF
--- a/src/grib2io/templates.py
+++ b/src/grib2io/templates.py
@@ -1006,7 +1006,7 @@ class LeadTime:
         try:
             pdt[_key[obj.pdtn]] = (
                 datetime.timedelta(hours=ivalue) + refdate
-            ).timetuple()[:5]
+            ).timetuple()[:6]
         except KeyError:
             if obj.pdtn == 48:
                 pdt[19] = ivalue / (


### PR DESCRIPTION
For product template numbers 8 through 12, the setting of leadTime was failing because of different shapes.