### PR TITLE
Add or edit multiple __set__ functions.

### DIFF
--- a/src/grib2io/utils/__init__.py
+++ b/src/grib2io/utils/__init__.py
@@ -90,11 +90,11 @@ def get_leadtime(idsec: ArrayLike, pdtn: int, pdt: ArrayLike) -> datetime.timede
     Parameters
     ----------
     idsec
-        Seqeunce containing GRIB2 Identification Section (Section 1).
+        Sequence containing GRIB2 Identification Section (Section 1).
     pdtn
         GRIB2 Product Definition Template Number
     pdt
-        Seqeunce containing GRIB2 Product Definition Template (Section 4).
+        Sequence containing GRIB2 Product Definition Template (Section 4).
 
     Returns
     -------

--- a/src/grib2io/xarray_backend.py
+++ b/src/grib2io/xarray_backend.py
@@ -718,6 +718,7 @@ class Grib2ioDataSet:
         ds = da.to_dataset(dim='variable')
         return ds
 
+
     def to_grib2(self, filename):
         """
         Write a DataSet to a grib2 file.
@@ -729,7 +730,7 @@ class Grib2ioDataSet:
         """
         ds = self._obj
 
-        for shortName in ds:
+        for shortName in sorted(ds):
             # make a DataArray from the "Data Variables" in the DataSet
             da = ds[shortName]
 
@@ -896,6 +897,7 @@ class Grib2ioDataArray:
         new_da.name = da.name
         return new_da
 
+
     def to_grib2(self, filename, mode="w"):
         """
         Write a DataArray to a grib2 file.
@@ -919,13 +921,13 @@ class Grib2ioDataArray:
             k for k in index_keys if k not in ["latitude", "longitude", "validDate"]
         ]
         indexes = []
-        for index in index_keys:
+        for index in sorted(index_keys):
             values = da.coords[index].values
             if not isinstance(values, np.ndarray):
                 continue
             if values.ndim != 1:
                 continue
-            listeach = [{index: value} for value in list(set(values))]
+            listeach = [{index: value} for value in sorted(set(values))]
             indexes.append(listeach)
 
         for selectors in itertools.product(*indexes):
@@ -949,8 +951,6 @@ class Grib2ioDataArray:
 
             for index, value in filters.items():
                 setattr(newmsg, index, value)
-
-            newmsg.pack()
 
             # write the message to file
             with grib2io.open(filename, mode=mode) as f:


### PR DESCRIPTION
* Created a _calculate_scale_factor function in templates.py to be used in the new ValueOf* __set__ functions.
* Added __set__ functions to all the ValueOf* classes that behind the scenes use the ScaledValue* and ScaleFactor* setters.
* Changed the ValueOf* __get__ to behind the scenes use the ScaledValue* and ScaleFactor*
* Fixed the LeadTime __set__ for messages that are an accumulating statistic to set both LeadTime to the beginning of the accumulating period and the accumulating end date to the appropriate parts of section4.
* Now when writing with to_grib2 the messages will be sorted, if writing from a DataSet will sort on shortName, then for each DataArray will sort on dimension names, then sort dimension values.