### PR TITLE
Clean up date time attribute setting.

### DIFF
--- a/src/grib2io/_grib2io.py
+++ b/src/grib2io/_grib2io.py
@@ -847,7 +847,7 @@ class _Grib2Message:
         """
         return (f'{self._msgnum}:d={self.refDate}:{self.shortName}:'
                 f'{self.fullName} ({self.units}):{self.level}:'
-                f'{self.leadTime}')
+                f'{self.leadTime+self.duration}')
 
 
     def _generate_signature(self):

--- a/src/grib2io/xarray_backend.py
+++ b/src/grib2io/xarray_backend.py
@@ -1110,7 +1110,7 @@ class Grib2ioDataArray:
         coords_keys = [
             k
             for k in da.coords.keys()
-            if (k in AVAILABLE_NON_GEO_DIMS) and (k in da.dims)
+            if k in AVAILABLE_NON_GEO_DIMS
         ]
 
         for grib2_name, value in kwargs.items():
@@ -1128,7 +1128,7 @@ class Grib2ioDataArray:
                 )
             if grib2_name in coords_keys:
                 warn(
-                    f"Skipping attribute '{grib2_name}' because it is a dimension coordinate and cannot be updated."
+                    f"Skipping attribute '{grib2_name}' because it is a coordinate. Use da.assign_coords() to change coordinate values."
                 )
                 continue
             if hasattr(newmsg, grib2_name):

--- a/tests/test_grib2_datetime_attrs.py
+++ b/tests/test_grib2_datetime_attrs.py
@@ -1,0 +1,41 @@
+import pytest
+import numpy as np
+import datetime
+import grib2io
+
+def test_datetime_attrs(request):
+    data = request.config.rootdir / 'tests' / 'data' / 'gfs_20221107'
+    with grib2io.open(data / 'gfs.t00z.pgrb2.1p00.f012_subset') as f:
+        msg = f['TMAX'][0]
+
+    expected_refDate = datetime.datetime(2022, 11, 7, 0, 0)
+    expected_leadTime = datetime.timedelta(seconds=21600)
+    expected_duration = datetime.timedelta(seconds=21600)
+    expected_validDate = datetime.datetime(2022, 11, 7, 12, 0)
+
+    assert msg.refDate == expected_refDate
+    assert msg.leadTime == expected_leadTime
+    assert msg.duration == expected_duration
+    assert msg.validDate == expected_validDate
+
+    msg.leadTime = datetime.timedelta(hours=24)
+
+    assert msg.refDate == datetime.datetime(2022, 11, 7, 0, 0)
+    assert msg.leadTime == datetime.timedelta(days=1)
+    assert msg.duration == datetime.timedelta(seconds=21600)
+    assert msg.validDate == datetime.datetime(2022, 11, 8, 6, 0)
+
+    msg.duration = datetime.timedelta(hours=18)
+
+    assert msg.refDate == datetime.datetime(2022, 11, 7, 0, 0)
+    assert msg.leadTime == datetime.timedelta(days=1)
+    assert msg.duration == datetime.timedelta(seconds=64800)
+    assert msg.validDate == datetime.datetime(2022, 11, 8, 18, 0)
+
+    msg.leadTime = datetime.timedelta(seconds=21600)
+    msg.duration = datetime.timedelta(seconds=21600)
+
+    assert msg.refDate == datetime.datetime(2022, 11, 7, 0, 0)
+    assert msg.leadTime == datetime.timedelta(seconds=21600)
+    assert msg.duration == datetime.timedelta(seconds=21600)
+    assert msg.validDate == datetime.datetime(2022, 11, 7, 12, 0)

--- a/tests/test_xarray_update_attrs.py
+++ b/tests/test_xarray_update_attrs.py
@@ -133,15 +133,6 @@ ORIGINAL_ATTRS = TESTGRIB["TMP"].attrs
         ),
         pytest.param(
             {
-                "leadTime": 4,
-            },  # kwargs
-            set,  # expected_type
-            set(),  # expected
-            None,
-            id="warning_dims",
-        ),
-        pytest.param(
-            {
                 "zebra": 4,
             },  # kwargs
             Warning,  # expected_type
@@ -151,39 +142,12 @@ ORIGINAL_ATTRS = TESTGRIB["TMP"].attrs
         ),
         pytest.param(
             {
-                "zebra": 4,
-            },  # kwargs
-            set,  # expected_type
-            set(),  # expected
-            None,  # error_message
-            id="warning_not_found",
-        ),
-        pytest.param(
-            {
                 "refDate": datetime.datetime(2022, 11, 7, 0, 0),
             },  # kwargs
-            set,  # expected_type
-            set(),  # expected
-            None,
+            Warning,  # expected_type
+            UserWarning,  # expected
+            "", # error message
             id="refDate",
-        ),
-        pytest.param(
-            {
-                "refDate": datetime.datetime(2021, 11, 7, 0, 0),
-            },  # kwargs
-            set,  # expected_type
-            {
-                (
-                    "GRIB2IO_section1",
-                    "[   7    0    2    1    1 2022   11    7    0    0    0    0    1]",
-                ),
-                (
-                    "GRIB2IO_section1",
-                    "[   7    0    2    1    1 2021   11    7    0    0    0    0    1]",
-                ),
-            },  # expected
-            None,
-            id="refDate_year",
         ),
         pytest.param(
             {
@@ -202,24 +166,6 @@ ORIGINAL_ATTRS = TESTGRIB["TMP"].attrs
             },  # expected
             None,
             id="year",
-        ),
-        pytest.param(
-            {
-                "refDate": datetime.datetime(2022, 10, 7, 0, 0),
-            },  # kwargs
-            set,  # expected_type
-            {
-                (
-                    "GRIB2IO_section1",
-                    "[   7    0    2    1    1 2022   11    7    0    0    0    0    1]",
-                ),
-                (
-                    "GRIB2IO_section1",
-                    "[   7    0    2    1    1 2022   10    7    0    0    0    0    1]",
-                ),
-            },  # expected
-            None,
-            id="refDate_month",
         ),
         pytest.param(
             {


### PR DESCRIPTION
This commit cleans up code for setting refDate, leadTime, and duration Grib2Message attributes.

The xarray backend now ignore those attrs when calling the grib2io.update_attrs() accessor method for DataArrays.

This commit references NOAA-MDL/grib2io#158