### PR TITLE
Feature/datatree

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - ipython
   - dask
   - nceplibs-g2c
+  - xarray>=2023.04.0
   - pip:
     - numpy
     - cython

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - ipython
   - dask
   - nceplibs-g2c
-  - xarray>=2023.04.0
+  - xarray
   - pip:
     - numpy
     - cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ dask
 numpy
 pyproj
 pytest
-xarray
+xarray>=2023.04.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ dask
 numpy
 pyproj
 pytest
-xarray>=2023.04.0
+xarray

--- a/src/grib2io/xarray_backend.py
+++ b/src/grib2io/xarray_backend.py
@@ -82,7 +82,7 @@ LEVEL_NAME_MAPPING = {
     220: "planetary_boundary_layer",
     233: "high_cloud_top_level",
     223: "medium_cloud_top_level",
-    213: "low_cloud_top_level"
+    213: "low_cloud_top_level",
     214: "low_cloud_layer",
     224: "medium_cloud_layer",
     234: "high_cloud_layer",

--- a/src/grib2io/xarray_backend.py
+++ b/src/grib2io/xarray_backend.py
@@ -49,6 +49,9 @@ AVAILABLE_NON_GEO_DIMS = [
 # Map numeric level codes to human-readable names
 LEVEL_NAME_MAPPING = {
     1: "surface",
+    7: "tropopause",
+    6: "max_wind_level",
+    10: "entire_atmosphere",
     100: "isobaric_surface",
     101: "mean_sea_level",
     102: "height_above_msl",
@@ -63,7 +66,10 @@ LEVEL_NAME_MAPPING = {
     200: "entire_atmosphere",
     201: "entire_ocean",
     204: "highest_freezing_level",
-    220: "planetary_boundary_layer"
+    220: "planetary_boundary_layer",
+    233: "high_cloud_top_level",
+    223: "medium_cloud_top_level",
+    213: "low_cloud_top_level"
 }
 
 # Define the order of hierarchy levels for the DataTree

--- a/src/grib2io/xarray_backend.py
+++ b/src/grib2io/xarray_backend.py
@@ -22,7 +22,7 @@ try:
     # Try importing DataTree to check if it's available
     xarray_version = importlib.metadata.version('xarray')
     xarray_parts = [int(x) if x.isdigit() else x for x in xarray_version.split('.')]
-    min_version_parts = [2023, 4, 0]
+    min_version_parts = [2024, 10, 0]
     HAS_DATATREE = xarray_parts >= min_version_parts
 except (ImportError, ValueError):
     HAS_DATATREE = False

--- a/src/grib2io/xarray_backend.py
+++ b/src/grib2io/xarray_backend.py
@@ -10,10 +10,22 @@ import logging
 import typing
 from warnings import warn
 from collections import defaultdict
+import importlib.metadata
 
 import numpy as np
 import pandas as pd
 import xarray as xr
+
+# Check if xarray version is at least 2023.04.0 which includes DataTree support
+xarray_version = importlib.metadata.version('xarray')
+xarray_parts = [int(x) if x.isdigit() else x for x in xarray_version.split('.')]
+min_version_parts = [2023, 4, 0]
+if xarray_parts < min_version_parts:
+    raise ImportError(
+        f"xarray version {xarray_version} is not supported. "
+        f"grib2io.xarray_backend requires xarray>=2023.04.0 for DataTree functionality."
+    )
+
 from xarray.backends import (
     BackendArray,
     BackendEntrypoint,

--- a/src/grib2io/xarray_backend.py
+++ b/src/grib2io/xarray_backend.py
@@ -83,6 +83,16 @@ LEVEL_NAME_MAPPING = {
     233: "high_cloud_top_level",
     223: "medium_cloud_top_level",
     213: "low_cloud_top_level"
+    214: "low_cloud_layer",
+    224: "medium_cloud_layer",
+    234: "high_cloud_layer",
+    215: "cloud_ceiling",
+    242: 'convective_cloud_bottom_level',
+    212: "low_cloud_bottom_level",
+    222: "medium_cloud_bottom_level",
+    232: "high_cloud_bottom_level",
+    243: "convective_cloud_top_level",
+
 }
 
 # Define the order of hierarchy levels for the DataTree

--- a/tests/test_datatree_backend.py
+++ b/tests/test_datatree_backend.py
@@ -8,7 +8,7 @@ try:
     # Try importing DataTree to check if it's available
     xarray_version = importlib.metadata.version('xarray')
     xarray_parts = [int(x) if x.isdigit() else x for x in xarray_version.split('.')]
-    min_version_parts = [2023, 4, 0]
+    min_version_parts = [2024, 10, 0]
     HAS_DATATREE = xarray_parts >= min_version_parts
     # Also verify DataTree class exists
     if HAS_DATATREE and not hasattr(xr, 'DataTree'):

--- a/tests/test_datatree_backend.py
+++ b/tests/test_datatree_backend.py
@@ -1,5 +1,24 @@
 import pytest
 import xarray as xr
+import importlib.metadata
+
+# Check if xarray version supports DataTree
+HAS_DATATREE = False
+try:
+    # Try importing DataTree to check if it's available
+    xarray_version = importlib.metadata.version('xarray')
+    xarray_parts = [int(x) if x.isdigit() else x for x in xarray_version.split('.')]
+    min_version_parts = [2023, 4, 0]
+    HAS_DATATREE = xarray_parts >= min_version_parts
+    # Also verify DataTree class exists
+    if HAS_DATATREE and not hasattr(xr, 'DataTree'):
+        HAS_DATATREE = False
+except (ImportError, ValueError):
+    HAS_DATATREE = False
+
+# Skip all tests if DataTree is not available
+pytestmark = pytest.mark.skipif(not HAS_DATATREE,
+                               reason="xarray version does not support DataTree functionality")
 
 def test_datatree_basic_structure(request):
     """Test basic DataTree structure creation from a GRIB2 file."""

--- a/tests/test_datatree_backend.py
+++ b/tests/test_datatree_backend.py
@@ -1,0 +1,192 @@
+import pytest
+import xarray as xr
+
+def test_datatree_basic_structure(request):
+    """Test basic DataTree structure creation from a GRIB2 file."""
+    data = request.config.rootdir / 'tests' / 'input_data' / 'gfs_20221107'
+
+    # Open the file as a DataTree
+    tree = xr.open_datatree(data / 'gfs.t00z.pgrb2.1p00.f012_subset', engine='grib2io')
+
+    # Verify the basic structure
+    assert isinstance(tree, xr.DataTree)
+
+    # Verify expected level types in the tree
+    # Surface level should be present (typeOfFirstFixedSurface=1)
+    assert 'surface' in tree.children
+
+    # Verify that each level branch has datasets or children
+    for level_name, level_node in tree.children.items():
+        # Each level node should either have a dataset or children
+        assert level_node.ds is not None or len(level_node.children) > 0
+
+def test_datatree_level_structure(request):
+    """Test that the DataTree level structure is correctly organized."""
+    data = request.config.rootdir / 'tests' / 'input_data' / 'gfs_20221107'
+
+    # Open the file as a DataTree
+    tree = xr.open_datatree(data / 'gfs.t00z.pgrb2.1p00.f012_subset', engine='grib2io')
+
+    # Check the isobaric_surface branch (should have multiple levels)
+    if 'isobaric_surface' in tree.children:
+        isobaric_node = tree['isobaric_surface']
+
+        # Check if it has data variables
+        if isobaric_node.ds is not None:
+            # If it has direct data, at least one data variable should be present
+            assert len(isobaric_node.ds.data_vars) > 0
+
+            # Check if the valueOfFirstFixedSurface dimension is present
+            if 'valueOfFirstFixedSurface' in isobaric_node.ds.dims:
+                # Verify it has multiple values
+                assert len(isobaric_node.ds.valueOfFirstFixedSurface) > 1
+
+        # Or it might have children by PDTN
+        elif len(isobaric_node.children) > 0:
+            # If it has children, check the first child
+            first_child = next(iter(isobaric_node.children.values()))
+            assert first_child.ds is not None
+            assert len(first_child.ds.data_vars) > 0
+
+def test_datatree_single_pdtn_optimization(request):
+    """Test that PDTN nodes are skipped when there's only one PDTN value."""
+    data = request.config.rootdir / 'tests' / 'input_data' / 'gfs_20221107'
+
+    # Open the file as a DataTree
+    tree = xr.open_datatree(data / 'gfs.t00z.pgrb2.1p00.f012_subset', engine='grib2io')
+
+    # Check the surface branch (should have a single PDTN=0)
+    if 'surface' in tree.children:
+        surface_node = tree['surface']
+
+        # The surface node should have data directly, not a 'pdtn_0' child
+        # This tests our optimization where PDTN nodes are skipped when only one exists
+        assert surface_node.ds is not None
+        assert len(surface_node.ds.data_vars) > 0
+
+        # There should not be a 'pdtn_0' child since it's the only PDTN
+        # and we're optimizing by skipping it
+        assert 'pdtn_0' not in surface_node.children
+
+def test_datatree_multiple_pdtn_branches(request):
+    """Test that PDTN nodes are correctly created when multiple PDTNs exist."""
+    data = request.config.rootdir / 'tests' / 'input_data'
+
+    # Try to open a file that might have multiple PDTNs
+    # If this file doesn't have multiple PDTNs, the test will be skipped
+    try:
+        tree = xr.open_datatree(data / 'gfs.complex.grib2', engine='grib2io')
+
+        # Look for a level type that has multiple PDTNs
+        found_multiple_pdtns = False
+        for level_name, level_node in tree.children.items():
+            # If there are at least two children that start with 'pdtn_'
+            pdtn_children = [name for name in level_node.children if name.startswith('pdtn_')]
+            if len(pdtn_children) > 1:
+                found_multiple_pdtns = True
+
+                # Verify that the PDTNs are correctly named
+                for pdtn_name in pdtn_children:
+                    assert pdtn_name.startswith('pdtn_')
+                    # Extract the PDTN number and verify it's a valid integer
+                    pdtn_num = pdtn_name[5:]  # Remove 'pdtn_' prefix
+                    assert pdtn_num.isdigit()
+                break
+
+        if not found_multiple_pdtns:
+            pytest.skip("No level with multiple PDTNs found")
+    except (FileNotFoundError, ValueError):
+        pytest.skip("Test file with multiple PDTNs not available")
+
+def test_datatree_perturbation_structure(request):
+    """Test DataTree structure with perturbation numbers."""
+    data = request.config.rootdir / 'tests' / 'input_data' / 'gfs_20221107'
+
+    try:
+        # Try to open a file with perturbation numbers
+        tree = xr.open_datatree(data / 'gfs.t00z.pgrb2.1p00.f012_subset', engine='grib2io')
+
+        # Look for a node with perturbation numbers
+        found_perturbations = False
+        for level_name, level_node in tree.children.items():
+            # Check this level node
+            found_at_level = _check_for_perturbations(level_node)
+            if found_at_level:
+                found_perturbations = True
+                break
+
+        if not found_perturbations:
+            pytest.skip("No perturbation numbers found in the test data")
+    except (FileNotFoundError, ValueError):
+        pytest.skip("Test file not available or issue with perturbation structure")
+
+def _check_for_perturbations(node):
+    """Helper function to check for perturbation numbers in a node or its children."""
+    # Check if this node has perturbation data
+    if node.ds is not None and 'perturbationNumber' in node.ds.coords:
+        return True
+
+    # Check children nodes for perturbations
+    for child_name, child_node in node.children.items():
+        # If the child is named like 'pert_0', 'pert_1', etc.
+        if child_name.startswith('pert_'):
+            return True
+
+        # Recursively check deeper if this child has perturbations
+        if _check_for_perturbations(child_node):
+            return True
+
+    return False
+
+def test_datatree_subset_by_level(request):
+    """Test subsetting the DataTree to specific level types."""
+    data = request.config.rootdir / 'tests' / 'input_data' / 'gfs_20221107'
+
+    # Open the file as a DataTree
+    tree = xr.open_datatree(data / 'gfs.t00z.pgrb2.1p00.f012_subset', engine='grib2io')
+
+    # Create filters for specific level types
+    filters = {'typeOfFirstFixedSurface': 1}  # Surface level
+
+    # Open the file again with the filter
+    surface_tree = xr.open_datatree(data / 'gfs.t00z.pgrb2.1p00.f012_subset', engine='grib2io', filters=filters)
+
+    # Verify that only the surface level is present
+    assert 'surface' in surface_tree.children
+    assert len(surface_tree.children) == 1  # Only surface level should be present
+
+def test_datatree_interp(request):
+    """Test interpolating a DataTree to a new grid."""
+    try:
+        from grib2io._grib2io import Grib2GridDef
+        data = request.config.rootdir / 'tests' / 'input_data' / 'gfs_20221107'
+
+        # Open the file as a DataTree
+        tree = xr.open_datatree(data / 'gfs.t00z.pgrb2.1p00.f012_subset', engine='grib2io')
+
+        # Create a target grid definition
+        gdtn_nbm = 30
+        gdt_nbm = [1, 0, 6371200, 255, 255, 255, 255, 100, 50, 19229000, 233723400,
+                   48, 25000000, 265000000, 2539703, 2539703, 0, 64, 25000000,
+                   25000000, -90000000, 0]
+        nbm_grid_def = Grib2GridDef(gdtn_nbm, gdt_nbm)
+
+        # Interpolate the tree
+        interp_tree = tree.grib2io.interp('neighbor', nbm_grid_def)
+
+        # Verify the interpolated tree has the same structure
+        assert isinstance(interp_tree, xr.DataTree)
+        assert set(tree.children.keys()) == set(interp_tree.children.keys())
+
+        # Check that a dataset in the tree has been interpolated
+        for level_name in tree.children:
+            # Find a node with data to check
+            if tree[level_name].ds is not None:
+                # Check that latitude/longitude dimensions match the new grid
+                assert interp_tree[level_name].ds.dims['x'] == 100
+                assert interp_tree[level_name].ds.dims['y'] == 50
+                break
+    except (ModuleNotFoundError, ImportError):
+        pytest.skip("Required modules not available for interpolation test")
+    except (AttributeError, KeyError):
+        pytest.skip("DataTree does not have expected structure for interpolation test")

--- a/tests/test_xarray_backend.py
+++ b/tests/test_xarray_backend.py
@@ -9,6 +9,7 @@ def test_named_filter(request):
     ds2 = xr.open_dataset(data / 'gfs.t00z.pgrb2.1p00.f012_subset', engine='grib2io', filters=filters)
     xr.testing.assert_equal(ds1, ds2)
 
+
 def test_multi_lead(request):
     data = request.config.rootdir / 'tests' / 'input_data' / 'gfs_20221107'
     filters = dict(productDefinitionTemplateNumber=0, typeOfFirstFixedSurface=1)


### PR DESCRIPTION
This PR allows for the ability to open a grib file requiring a lot of filters to access multiple data arrays into a single `xarray.DataTree`.  This creates a tree'd structure which users can then go in and access without knowing the filters needed beforehand. 

### Enhancements to `DataTree` Test Coverage:
* [`tests/test_datatree_backend.py`](diffhunk://#diff-ac5e3db3166878c32bd681190a417ec0ec1c74ec49988e3b0e42b7d2fd50897fR1-R192): Added multiple new test cases to validate the structure, optimization, subsetting, and interpolation of `DataTree` objects created from GRIB2 files. These include tests for basic structure, level organization, PDTN optimizations, perturbation structures, subsetting by levels, and interpolation to new grids.

### Minor Code Cleanup:
* [`tests/test_xarray_backend.py`](diffhunk://#diff-302c0610e1d8fa33c8b25c1781be5c0a8f99dac249113b46535779a81cf03cb1R12): Removed an unnecessary blank line in the `test_named_filter` function for better readability.