### PR TITLE
Update datetime attrs.

### DIFF
--- a/tests/test_grib2_datetime_attrs.py
+++ b/tests/test_grib2_datetime_attrs.py
@@ -9,8 +9,8 @@ def test_datetime_attrs(request):
         msg = f['TMAX'][0]
 
     expected_refDate = datetime.datetime(2022, 11, 7, 0, 0)
-    expected_leadTime = datetime.timedelta(seconds=21600)
-    expected_duration = datetime.timedelta(seconds=21600)
+    expected_leadTime = datetime.timedelta(seconds=43200) # 12-hours (ending lead time)
+    expected_duration = datetime.timedelta(seconds=21600) # 6-hour duration
     expected_validDate = datetime.datetime(2022, 11, 7, 12, 0)
 
     assert msg.refDate == expected_refDate
@@ -18,24 +18,28 @@ def test_datetime_attrs(request):
     assert msg.duration == expected_duration
     assert msg.validDate == expected_validDate
 
+    # Change lead time from 12 hours to 24 hours.
     msg.leadTime = datetime.timedelta(hours=24)
 
     assert msg.refDate == datetime.datetime(2022, 11, 7, 0, 0)
     assert msg.leadTime == datetime.timedelta(days=1)
     assert msg.duration == datetime.timedelta(seconds=21600)
-    assert msg.validDate == datetime.datetime(2022, 11, 8, 6, 0)
+    assert msg.validDate == datetime.datetime(2022, 11, 8, 0, 0)
 
+    # Change duration from 6 hours to 18 hours.
     msg.duration = datetime.timedelta(hours=18)
 
     assert msg.refDate == datetime.datetime(2022, 11, 7, 0, 0)
     assert msg.leadTime == datetime.timedelta(days=1)
     assert msg.duration == datetime.timedelta(seconds=64800)
-    assert msg.validDate == datetime.datetime(2022, 11, 8, 18, 0)
+    assert msg.validDate == datetime.datetime(2022, 11, 8, 0, 0)
 
+    # Change lead time to 6 hours
     msg.leadTime = datetime.timedelta(seconds=21600)
+    # Change duration to 6 hours
     msg.duration = datetime.timedelta(seconds=21600)
 
     assert msg.refDate == datetime.datetime(2022, 11, 7, 0, 0)
     assert msg.leadTime == datetime.timedelta(seconds=21600)
     assert msg.duration == datetime.timedelta(seconds=21600)
-    assert msg.validDate == datetime.datetime(2022, 11, 7, 12, 0)
+    assert msg.validDate == datetime.datetime(2022, 11, 7, 6, 0)


### PR DESCRIPTION
This update fixes some undesired behavior for setting and getting datetime attributes.

Original changes in #158, we overlooked that setting duration should not impact the validDate since leadTime is the ending hour.