### PR TITLE
save_index options in the xarray backend

### DIFF
--- a/src/grib2io/_grib2io.py
+++ b/src/grib2io/_grib2io.py
@@ -251,8 +251,8 @@ class open():
                             index = pickle.load(file)
                         self._index = index
                     except Exception as e:
-                        print(f"found indexfile: {self.indexfile}, but unable to load it: {e}")
-                        print(f"re-forming index from grib2file, but not writing indexfile")
+                        warnings.warn(f"found indexfile: {self.indexfile}, but unable to load it: {e}\n" 
+                                      f"re-forming index from grib2file, but not writing indexfile")
                         self._index = build_index(self._filehandle)
                     self._hasindex = True
                 else:
@@ -261,7 +261,7 @@ class open():
                         try:
                             serialize_index(self._index, self.indexfile)
                         except Exception as e:
-                            print(f"index was not serialized for future use: {e}")
+                            warnings.warn(f"index was not serialized for future use: {e}")
 
                 self._msgs = msgs_from_index(self._index, filehandle=self._filehandle)
 

--- a/src/grib2io/xarray_backend.py
+++ b/src/grib2io/xarray_backend.py
@@ -447,6 +447,7 @@ class GribBackendEntrypoint(BackendEntrypoint):
         filename,
         *,
         drop_variables=None,
+        save_index=True,
         filters: typing.Mapping[str, typing.Any] = dict(),
         data_model=None
     ):
@@ -468,7 +469,7 @@ class GribBackendEntrypoint(BackendEntrypoint):
         open_dataset
             Xarray dataset of grib2 messages.
         """
-        with grib2io.open(filename, _xarray_backend=True) as f:
+        with grib2io.open(filename, save_index=save_index, _xarray_backend=True) as f:
             file_index = pd.DataFrame(f._index)
             file_index = file_index.assign(msg=msgs_from_index(f._index))
 
@@ -507,6 +508,7 @@ class GribBackendEntrypoint(BackendEntrypoint):
         filename,
         *,
         drop_variables=None,
+        save_index=True,
         filters: typing.Mapping[str, typing.Any] = None,
         stack_vertical: bool = False,
     ):
@@ -536,7 +538,7 @@ class GribBackendEntrypoint(BackendEntrypoint):
             filters = {}
 
         # Open the file without any filters first to get all messages
-        with grib2io.open(filename, _xarray_backend=True) as f:
+        with grib2io.open(filename, save_index=save_index, _xarray_backend=True) as f:
             file_index = pd.DataFrame(f._index)
             file_index = file_index.assign(msg=msgs_from_index(f._index))
 

--- a/tests/test_xarray_backend.py
+++ b/tests/test_xarray_backend.py
@@ -9,6 +9,18 @@ def test_named_filter(request):
     ds2 = xr.open_dataset(data / 'gfs.t00z.pgrb2.1p00.f012_subset', engine='grib2io', filters=filters)
     xr.testing.assert_equal(ds1, ds2)
 
+def test_save_index(request: pytest.FixtureRequest):
+    data = request.config.rootpath / 'tests' / 'input_data' / 'gfs_20221107'
+    fname = 'gfs.t00z.pgrb2.1p00.f012_subset'
+    idx_glob_str = f'{fname}.*.grib2ioidx'
+
+    for file in data.glob(idx_glob_str):
+        file.unlink()
+
+    filters = dict(productDefinitionTemplateNumber=0, typeOfFirstFixedSurface=1)
+    ds = xr.open_dataset(data / fname, engine='grib2io', filters=filters, save_index=False)
+
+    assert len(list(data.glob(idx_glob_str))) == 0
 
 def test_multi_lead(request):
     data = request.config.rootdir / 'tests' / 'input_data' / 'gfs_20221107'

--- a/tests/test_xarray_datatree_backend.py
+++ b/tests/test_xarray_datatree_backend.py
@@ -177,3 +177,15 @@ def test_datatree_subset_by_level(request):
     # Verify that only the surface level is present
     assert 'surface' in surface_tree.children
     assert len(surface_tree.children) == 1  # Only surface level should be present
+
+def test_datatree_save_index(request: pytest.FixtureRequest):
+    data = request.config.rootpath / 'tests' / 'input_data' / 'gfs_20221107'
+    fname = 'gfs.t00z.pgrb2.1p00.f012_subset'
+    idx_glob_str = f'{fname}.*.grib2ioidx'
+
+    for file in data.glob(idx_glob_str):
+        file.unlink()
+
+    ds = xr.open_datatree(data / fname, engine='grib2io', save_index=False)
+    
+    assert len(list(data.glob(idx_glob_str))) == 0


### PR DESCRIPTION
In v2.6, grib2io added support for writing indexes, including a `save_index` option in `grib2io.open()`. I'm trying to read grib files using the xarray backend from a directory I don't have permission to write to. In this case, `grib2io.open()` would yell at you about not being able to save the index file, but there's no way to shut that message off because

1) The `save_index` option wasn't added to the xarray backend
2) The messages were issued using `print()`, so you can't silence them using Python's warnings machinery.

This PR fixes both of those.

For my particular use case, there's not a whole lot of advantage to be gained by saving the index file in a different directory that I do have permission to write to, but I could see that being useful for someone. However, I haven't implemented that here.