### PR TITLE
Introducing basic cli utilites

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ grib2io = "grib2io.xarray_backend:GribBackendEntrypoint"
 Documentation = "https://noaa-mdl.github.io/grib2io"
 Repository = "https://github.com/NOAA-MDL/grib2io"
 
+[project.scripts]
+grib2io = "grib2io.cli.main:main"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 packages = ["grib2io", "grib2io.tables", "grib2io.utils"]

--- a/src/grib2io/_grib2io.py
+++ b/src/grib2io/_grib2io.py
@@ -354,10 +354,24 @@ class open:
             return self.select(shortName=key)
         elif isinstance(key, slice):
             return self._msgs[key]
+        elif isinstance(key, (list, tuple, set)):
+            if len(key) == 0:
+                return iter(self._msgs)
+            indices = sorted(key) if isinstance(key, set) else key
+            def _iter_msgs():
+                for i in indices:
+                    if not isinstance(i, int):
+                        raise TypeError(f"indices must be integers; got {type(i).__name__}")
+                    if abs(i) >= len(self._msgs):
+                        raise IndexError(f"index out of range: {i}")
+                    yield self._msgs[i]
+            return _iter_msgs()
         else:
             raise KeyError(
-                "Key must be an integer, slice, or GRIB2 variable shortName."
+                "Key must be an integer, slice, GRIB2 variable shortName, "
+                "or an iterable of integer indices."
             )
+
 
     @property
     def levels(self):

--- a/src/grib2io/_grib2io.py
+++ b/src/grib2io/_grib2io.py
@@ -358,20 +358,23 @@ class open:
             if len(key) == 0:
                 return iter(self._msgs)
             indices = sorted(key) if isinstance(key, set) else key
+
             def _iter_msgs():
                 for i in indices:
                     if not isinstance(i, int):
-                        raise TypeError(f"indices must be integers; got {type(i).__name__}")
+                        raise TypeError(
+                            f"indices must be integers; got {type(i).__name__}"
+                        )
                     if abs(i) >= len(self._msgs):
                         raise IndexError(f"index out of range: {i}")
                     yield self._msgs[i]
+
             return _iter_msgs()
         else:
             raise KeyError(
                 "Key must be an integer, slice, GRIB2 variable shortName, "
                 "or an iterable of integer indices."
             )
-
 
     @property
     def levels(self):

--- a/src/grib2io/cli/create_index.py
+++ b/src/grib2io/cli/create_index.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import argparse
-#import json
 import sys
-from typing import Any
 
 import grib2io
 
@@ -15,13 +13,12 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         description="Create a grib2io-formatted GRIB2 index file",
     )
     p.add_argument("path", help="GRIB2 file")
-    #p.add_argument("-l", "--long", action="store_true", help="Show more columns")
-    #p.add_argument("--json", action="store_true", help="Output JSON Lines (one object per message)")
     p.set_defaults(func=cmd_create_index)
 
 
 def cmd_create_index(args: argparse.Namespace) -> int:
 
+    # Open GRIB2 file.
     try:
         g = grib2io.open(args.path, mode="r", use_index=False, save_index=True)
     except Exception as e:

--- a/src/grib2io/cli/create_index.py
+++ b/src/grib2io/cli/create_index.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import argparse
+#import json
+import sys
+from typing import Any
+
+import grib2io
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser(
+        "create-index",
+        help="Create a grib2io-formatted GRIB2 index file",
+        description="Create a grib2io-formatted GRIB2 index file",
+    )
+    p.add_argument("path", help="GRIB2 file")
+    #p.add_argument("-l", "--long", action="store_true", help="Show more columns")
+    #p.add_argument("--json", action="store_true", help="Output JSON Lines (one object per message)")
+    p.set_defaults(func=cmd_create_index)
+
+
+def cmd_create_index(args: argparse.Namespace) -> int:
+
+    try:
+        g = grib2io.open(args.path, mode="r", use_index=False, save_index=True)
+    except Exception as e:
+        print(f"grib2io: failed to open {args.path!r}: {e}", file=sys.stderr)
+        return 2
+
+    return 0

--- a/src/grib2io/cli/create_index.py
+++ b/src/grib2io/cli/create_index.py
@@ -20,7 +20,7 @@ def cmd_create_index(args: argparse.Namespace) -> int:
 
     # Open GRIB2 file.
     try:
-        g = grib2io.open(args.path, mode="r", use_index=False, save_index=True)
+        _ = grib2io.open(args.path, mode="r", use_index=False, save_index=True)
     except Exception as e:
         print(f"grib2io: failed to open {args.path!r}: {e}", file=sys.stderr)
         return 2

--- a/src/grib2io/cli/ls.py
+++ b/src/grib2io/cli/ls.py
@@ -30,7 +30,9 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         description="Inventory messages in a GRIB2 file",
     )
     p.add_argument("path", help="GRIB2 file")
-    p.add_argument("-i", dest="indices", action=ReadIndicesFromStdin, nargs=0, default=[], help="Read grib2io ls output from stdin")
+    p.add_argument("-i", "--stdin", dest="indices", action=ReadIndicesFromStdin, nargs=0, default=[], help="Read grib2io ls output from stdin")
+    p.add_argument("-o", "--output", dest="output", metavar="FILE", type=str, default=None, help="Write selected GRIB2 messages to FILE.")
+
     p.set_defaults(func=cmd_ls)
 
 
@@ -43,8 +45,17 @@ def cmd_ls(args: argparse.Namespace) -> int:
         print(f"grib2io: failed to open {args.path!r}: {e}", file=sys.stderr)
         return 2
 
+    if args.output is not None:
+        output = grib2io.open(args.output, mode="w")
+
     # Iterate messages.
     for msg in g[args.indices]:
         print(msg, flush=True)
+        # Add any per message action below.
+        if args.output: output.write(msg)
 
+    if args.output is not None:
+        output.close()
+
+    g.close()
     return 0

--- a/src/grib2io/cli/ls.py
+++ b/src/grib2io/cli/ls.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+#import json
+import sys
+from typing import Any
+
+import grib2io
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser(
+        "ls",
+        help="List (inventory) messages in a GRIB2 file",
+        description="Inventory messages in a GRIB2 file",
+    )
+    p.add_argument("path", help="GRIB2 file")
+    #p.add_argument("-l", "--long", action="store_true", help="Show more columns")
+    #p.add_argument("--json", action="store_true", help="Output JSON Lines (one object per message)")
+    p.set_defaults(func=cmd_ls)
+
+
+def _safe_get(d: dict[str, Any], *keys: str, default: str = "") -> Any:
+    for k in keys:
+        if k in d:
+            return d[k]
+    return default
+
+
+def cmd_ls(args: argparse.Namespace) -> int:
+    # If open() auto-indexes, then just opening will populate the dict.
+    try:
+        g = grib2io.open(args.path, mode="r", use_index=True, save_index=False)
+    except Exception as e:
+        print(f"grib2io: failed to open {args.path!r}: {e}", file=sys.stderr)
+        return 2
+
+    for msg in g:
+        print(msg, flush=True)
+
+#    # Assume your instance variable is something like `g.msgs` or `g.msg_dict`.
+#    # Replace `g.msgs` with the real attribute name.
+#    msg_index: dict[int, dict[str, Any]] = g.msgs  # <-- CHANGE THIS to your actual dict attribute
+#
+#    # Stable ordering by message number / offset
+#    items = sorted(msg_index.items(), key=lambda kv: kv[0])
+#
+#    if args.json:
+#        for msgnum, meta in items:
+#            # ensure msgnum is included even if meta doesn't contain it
+#            out = dict(meta)
+#            out.setdefault("msgnum", msgnum)
+#            print(json.dumps(out, default=str))
+#        return 0
+#
+#    # Human table header
+#    if args.long:
+#        # Customize these columns to match what you actually store
+#        header = f"{'msg':>6} {'discip':>5} {'cat':>3} {'num':>3} {'level':>10} {'vt':>20} {'name':<}"
+#    else:
+#        header = f"{'msg':>6} {'discip':>5} {'cat':>3} {'num':>3} {'name':<}"
+#    print(header)
+#
+#    for msgnum, meta in items:
+#        discip = _safe_get(meta, "discipline", default="")
+#        cat = _safe_get(meta, "parameterCategory", "category", default="")
+#        num = _safe_get(meta, "parameterNumber", "number", default="")
+#        name = _safe_get(meta, "shortName", "name", "parameterName", default="")
+#
+#        if args.long:
+#            level = _safe_get(meta, "typeOfFirstFixedSurface", "level", default="")
+#            vt = _safe_get(meta, "validTime", "forecastTime", default="")
+#            print(f"{msgnum:6d} {str(discip):>5} {str(cat):>3} {str(num):>3} {str(level):>10} {str(vt):>20} {name}")
+#        else:
+#            print(f"{msgnum:6d} {str(discip):>5} {str(cat):>3} {str(num):>3} {name}")
+
+    return 0
+

--- a/src/grib2io/cli/ls.py
+++ b/src/grib2io/cli/ls.py
@@ -8,6 +8,7 @@ import grib2io
 
 class ReadIndicesFromStdin(argparse.Action):
     """Action class for "-i" flag"""
+
     def __call__(self, parser, namespace, values, option_string=None):
         # Error if no stdin
         if sys.stdin.isatty():
@@ -15,9 +16,7 @@ class ReadIndicesFromStdin(argparse.Action):
 
         # Read from stdin
         data = sys.stdin.read()
-        indices = [
-            int(line.split(":")[0]) for line in data.split("\n")[:-1]
-        ]
+        indices = [int(line.split(":")[0]) for line in data.split("\n")[:-1]]
 
         # Write into a attribute
         setattr(namespace, "indices", indices)
@@ -30,8 +29,24 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         description="Inventory messages in a GRIB2 file",
     )
     p.add_argument("path", help="GRIB2 file")
-    p.add_argument("-i", "--stdin", dest="indices", action=ReadIndicesFromStdin, nargs=0, default=[], help="Read grib2io ls output from stdin")
-    p.add_argument("-o", "--output", dest="output", metavar="FILE", type=str, default=None, help="Write selected GRIB2 messages to FILE.")
+    p.add_argument(
+        "-i",
+        "--stdin",
+        dest="indices",
+        action=ReadIndicesFromStdin,
+        nargs=0,
+        default=[],
+        help="Read grib2io ls output from stdin",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        metavar="FILE",
+        type=str,
+        default=None,
+        help="Write selected GRIB2 messages to FILE.",
+    )
 
     p.set_defaults(func=cmd_ls)
 
@@ -52,7 +67,8 @@ def cmd_ls(args: argparse.Namespace) -> int:
     for msg in g[args.indices]:
         print(msg, flush=True)
         # Add any per message action below.
-        if args.output: output.write(msg)
+        if args.output:
+            output.write(msg)
 
     if args.output is not None:
         output.close()

--- a/src/grib2io/cli/ls.py
+++ b/src/grib2io/cli/ls.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
 import argparse
-#import json
 import sys
-from typing import Any
 
 import grib2io
+
+
+class ReadIndicesFromStdin(argparse.Action):
+    """Action class for "-i" flag"""
+    def __call__(self, parser, namespace, values, option_string=None):
+        # Error if no stdin
+        if sys.stdin.isatty():
+            parser.error(f"{option_string} requires piped stdin (no input detected).")
+
+        # Read from stdin
+        data = sys.stdin.read()
+        indices = [
+            int(line.split(":")[0]) for line in data.split("\n")[:-1]
+        ]
+
+        # Write into a attribute
+        setattr(namespace, "indices", indices)
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -15,64 +30,21 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         description="Inventory messages in a GRIB2 file",
     )
     p.add_argument("path", help="GRIB2 file")
-    #p.add_argument("-l", "--long", action="store_true", help="Show more columns")
-    #p.add_argument("--json", action="store_true", help="Output JSON Lines (one object per message)")
+    p.add_argument("-i", dest="indices", action=ReadIndicesFromStdin, nargs=0, default=[], help="Read grib2io ls output from stdin")
     p.set_defaults(func=cmd_ls)
 
 
-def _safe_get(d: dict[str, Any], *keys: str, default: str = "") -> Any:
-    for k in keys:
-        if k in d:
-            return d[k]
-    return default
-
-
 def cmd_ls(args: argparse.Namespace) -> int:
-    # If open() auto-indexes, then just opening will populate the dict.
+
+    # Open GRIB2 file.
     try:
         g = grib2io.open(args.path, mode="r", use_index=True, save_index=False)
     except Exception as e:
         print(f"grib2io: failed to open {args.path!r}: {e}", file=sys.stderr)
         return 2
 
-    for msg in g:
+    # Iterate messages.
+    for msg in g[args.indices]:
         print(msg, flush=True)
 
-#    # Assume your instance variable is something like `g.msgs` or `g.msg_dict`.
-#    # Replace `g.msgs` with the real attribute name.
-#    msg_index: dict[int, dict[str, Any]] = g.msgs  # <-- CHANGE THIS to your actual dict attribute
-#
-#    # Stable ordering by message number / offset
-#    items = sorted(msg_index.items(), key=lambda kv: kv[0])
-#
-#    if args.json:
-#        for msgnum, meta in items:
-#            # ensure msgnum is included even if meta doesn't contain it
-#            out = dict(meta)
-#            out.setdefault("msgnum", msgnum)
-#            print(json.dumps(out, default=str))
-#        return 0
-#
-#    # Human table header
-#    if args.long:
-#        # Customize these columns to match what you actually store
-#        header = f"{'msg':>6} {'discip':>5} {'cat':>3} {'num':>3} {'level':>10} {'vt':>20} {'name':<}"
-#    else:
-#        header = f"{'msg':>6} {'discip':>5} {'cat':>3} {'num':>3} {'name':<}"
-#    print(header)
-#
-#    for msgnum, meta in items:
-#        discip = _safe_get(meta, "discipline", default="")
-#        cat = _safe_get(meta, "parameterCategory", "category", default="")
-#        num = _safe_get(meta, "parameterNumber", "number", default="")
-#        name = _safe_get(meta, "shortName", "name", "parameterName", default="")
-#
-#        if args.long:
-#            level = _safe_get(meta, "typeOfFirstFixedSurface", "level", default="")
-#            vt = _safe_get(meta, "validTime", "forecastTime", default="")
-#            print(f"{msgnum:6d} {str(discip):>5} {str(cat):>3} {str(num):>3} {str(level):>10} {str(vt):>20} {name}")
-#        else:
-#            print(f"{msgnum:6d} {str(discip):>5} {str(cat):>3} {str(num):>3} {name}")
-
     return 0
-

--- a/src/grib2io/cli/main.py
+++ b/src/grib2io/cli/main.py
@@ -6,10 +6,10 @@ import sys
 from .create_index import add_parser as add_create_index_parser
 from .ls import add_parser as add_ls_parser
 
-COMMANDS = [
+COMMANDS = {
     "create-index",
     "ls"
-]
+}
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/grib2io/cli/main.py
+++ b/src/grib2io/cli/main.py
@@ -6,14 +6,13 @@ import sys
 from .create_index import add_parser as add_create_index_parser
 from .ls import add_parser as add_ls_parser
 
-COMMANDS = {
-    "create-index",
-    "ls"
-}
+COMMANDS = {"create-index", "ls"}
 
 
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(prog="grib2io", description="Command line utilities for grib2io")
+    p = argparse.ArgumentParser(
+        prog="grib2io", description="Command line utilities for grib2io"
+    )
     sub = p.add_subparsers(dest="command", required=True)
 
     add_ls_parser(sub)
@@ -36,4 +35,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/src/grib2io/cli/main.py
+++ b/src/grib2io/cli/main.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .create_index import add_parser as add_create_index_parser
+from .ls import add_parser as add_ls_parser
+
+COMMANDS = [
+    "create-index",
+    "ls"
+]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="grib2io", description="Command line utilities for grib2io")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    add_ls_parser(sub)
+    add_create_index_parser(sub)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    # Dispatch
+    if args.command in COMMANDS:
+        return args.func(args)
+
+    parser.error("Unknown command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/src/grib2io/templates.py
+++ b/src/grib2io/templates.py
@@ -107,11 +107,6 @@ class Grib2Metadata:
     def __call__(self):
         return self.value
 
-    def __hash__(self):
-        # AS- added hash() to self.value as pandas was raising error about some
-        # non integer returns from hash method
-        return hash(self.value)
-
     def __repr__(self):
         return f"{self.__class__.__name__}({self.value}, table = '{self.table}')"
 


### PR DESCRIPTION
This PR introduces basic cli utilites.  The cli framework has been structured as a main `grib2io` utility command with sub-commands for controlling primary functionality.  In this initial implementation, the following subcommands are provided:
* `ls` - list GRIB2 messages (simliar to wgrib2).  This also provides the ability to parse a GRIB2 file by reading its own stdout as stdin.
* `create-index` - create a grib2io-specific index file.