### PR TITLE
fix: expand shared sections when flattening GRIB2 submessages

### DIFF
--- a/src/grib2io/_grib2io.py
+++ b/src/grib2io/_grib2io.py
@@ -840,11 +840,12 @@ def msgs_from_index(index: dict, filehandle=None):
     - The `_msgnum` attribute of each message is assigned sequentially to
       preserve message order.
     """
+    n = len(index["section4"])
     zipped = zip(
-        index["section0"],
-        index["section1"],
+        index["section0"] * n if len(index["section0"]) < n else index["section0"],
+        index["section1"] * n if len(index["section1"]) < n else index["section1"],
         index["section2"],
-        index["section3"],
+        index["section3"] * n if len(index["section3"]) < n else index["section3"],
         index["section4"],
         index["section5"],
         index["bmapflag"],

--- a/src/grib2io/_grib2io.py
+++ b/src/grib2io/_grib2io.py
@@ -841,11 +841,15 @@ def msgs_from_index(index: dict, filehandle=None):
       preserve message order.
     """
     n = len(index["section4"])
+    def _expand(lst):
+        if len(lst) < n:
+            return [lst[0].copy() for _ in range(n)]
+        return lst
     zipped = zip(
-        index["section0"] * n if len(index["section0"]) < n else index["section0"],
-        index["section1"] * n if len(index["section1"]) < n else index["section1"],
+        _expand(index["section0"]),
+        _expand(index["section1"]),
         index["section2"],
-        index["section3"] * n if len(index["section3"]) < n else index["section3"],
+        _expand(index["section3"]),
         index["section4"],
         index["section5"],
         index["bmapflag"],


### PR DESCRIPTION
## Bug Description

`grib2io.open()` returns only 1 message from GRIB2 files that use submessages, even though the file contains many messages.

The documentation states that grib2io _"accommodates for GRIB2 submessages by flattening them into multiple individual messages"_, but this is not working correctly.

## Root Cause

In `msgs_from_index()`, the index for a submessage file looks like this:

```python
index["section0"]  # length: 1  (shared across all submessages)
index["section1"]  # length: 1  (shared)
index["section2"]  # length: N
index["section3"]  # length: 1  (shared)
index["section4"]  # length: N
index["section5"]  # length: N
index["bmapflag"]  # length: N
```

The `zip()` call stops at the shortest iterable (length 1), so only 1 `Grib2Message` is created instead of N.

## Fix

Repeat the shared sections to match the number of submessages before zipping. The `< n` guard preserves correct behavior for files with multiple independent GRIB messages (no submessages), where all lists are already the same length.

## Reproduction

Confirmed with JMA (Japan Meteorological Agency) GPV files, which are structured as a single GRIB2 message containing multiple submessages. JMA GPV data is publicly available via Kyoto University RISH:
https://database.rish.kyoto-u.ac.jp/arch/jmadata/data/gpv/original/

```python
import grib2io
import pygrib

# JMA GPV file with 192 submessages
grbs = grib2io.open("Z__C_RJTD_20240125000000_GSM_GPV_Rjp_Gll0p1deg_Lsurf_FD0903-1100_grib2.bin")
print(len(grbs))   # 1  (before fix) / 192  (after fix)

pgrbs = pygrib.open("Z__C_RJTD_20240125000000_GSM_GPV_Rjp_Gll0p1deg_Lsurf_FD0903-1100_grib2.bin")
print(pgrbs.messages)  # 192
```

Index structure for the same file:

```python
idx = grbs._index
# section0: 1, section1: 1, section3: 1
# section4: 192, section5: 192
```