### PR TITLE
BUG: Allow duration calculation when ntime >= 2

### DIFF
--- a/src/grib2io/utils/__init__.py
+++ b/src/grib2io/utils/__init__.py
@@ -180,7 +180,7 @@ def get_duration(pdtn: int, pdt: ArrayLike) -> datetime.timedelta:
             pdt[templates.UnitOfTimeRangeOfStatisticalProcess._key[pdtn]],
             "scale_time_seconds",
         )
-        d = ntime * duration_unit * pdt[templates.TimeRangeOfStatisticalProcess._key[pdtn]]
+        d = min(ntime, 1) * duration_unit * pdt[templates.TimeRangeOfStatisticalProcess._key[pdtn]]
     else:
         d = 0
     return datetime.timedelta(seconds=int(d))


### PR DESCRIPTION
I ran into a dataset of monthly means of daily means, which denoted this using two blocks in section 4.  The duration I calculated was 29 days, but the duration reported as an XArray coord was 58 days.  This line of code seems to be the difference, and the change should capture the intent.

That particular example would benefit from adding the duration of the second interval to report that June has 30 days, but I suspect that varies by implementation, and so did not attempt to add that change.  On testing, this resulted in a more sensible lead_time and time as well, and leaving the duration as 29 days instead of 30 meant the time got reported as the last day of the month, rather than the start of the next month, which is probably easier to work with and understand.