### PR TITLE
Update units and Grib2Message __str__

### DIFF
--- a/src/grib2io/_grib2io.py
+++ b/src/grib2io/_grib2io.py
@@ -1065,7 +1065,15 @@ class _Grib2Message:
             A formatted string representation of the object, including
             selected attributes.
         """
-        return f"{self._msgnum}:d={self.refDate}:{self.shortName}:{self.fullName} ({self.units}):{self.level}:{self.leadTime}"
+        strmsg = f"{self._msgnum}:d={self.refDate}:{self.shortName}:{self.fullName} ({self.units}):{self.level}:{self.leadTime}"
+        if self.pdtn in {5, 9}:
+            strmsg = f"{self._msgnum}:d={self.refDate}:{self.shortName}:{self.fullName} (%):{self.level}:{self.leadTime}:{self.duration}:{self.threshold} ({self.units})"
+        elif self.pdtn in {6, 10}:
+            pctstr = utils.percentile_string(self.percentileValue)
+            strmsg = f"{self._msgnum}:d={self.refDate}:{self.shortName}:{self.fullName} ({self.units}):{self.level}:{self.leadTime}:{self.duration}:{pctstr}"
+        elif self.pdtn in {8}:
+            strmsg = f"{self._msgnum}:d={self.refDate}:{self.shortName}:{self.fullName} ({self.units}):{self.level}:{self.leadTime}:{self.duration} {self.statisticalProcess.definition}"
+        return strmsg
 
     def _generate_signature(self):
         """Generature SHA-1 hash string from GRIB2 integer sections."""

--- a/src/grib2io/_grib2io.py
+++ b/src/grib2io/_grib2io.py
@@ -1065,15 +1065,36 @@ class _Grib2Message:
             A formatted string representation of the object, including
             selected attributes.
         """
-        strmsg = f"{self._msgnum}:d={self.refDate}:{self.shortName}:{self.fullName} ({self.units}):{self.level}:{self.leadTime}"
-        if self.pdtn in {5, 9}:
-            strmsg = f"{self._msgnum}:d={self.refDate}:{self.shortName}:{self.fullName} (%):{self.level}:{self.leadTime}:{self.duration}:{self.threshold} ({self.units})"
-        elif self.pdtn in {6, 10}:
-            pctstr = utils.percentile_string(self.percentileValue)
-            strmsg = f"{self._msgnum}:d={self.refDate}:{self.shortName}:{self.fullName} ({self.units}):{self.level}:{self.leadTime}:{self.duration}:{pctstr}"
-        elif self.pdtn in {8}:
-            strmsg = f"{self._msgnum}:d={self.refDate}:{self.shortName}:{self.fullName} ({self.units}):{self.level}:{self.leadTime}:{self.duration} {self.statisticalProcess.definition}"
-        return strmsg
+        pdtn = self.pdtn
+        prefix = (
+            f"{self._msgnum}:d={self.refDate}:"
+            f"{self.shortName}:{self.fullName}"
+        )
+
+        if pdtn in {5, 9}:
+            return (
+                f"{prefix} (%):{self.level}:{self.leadTime}:"
+                f"{self.duration}:{self.threshold} "
+                f"({self.parameterUnits})"
+            )
+
+        if pdtn in {6, 10}:
+            percentile = utils.percentile_string(self.percentileValue)
+            return (
+                f"{prefix} ({self.units}):{self.level}:{self.leadTime}:"
+                f"{self.duration}:{percentile}"
+            )
+
+        if pdtn == 8:
+            return (
+                f"{prefix} ({self.units}):{self.level}:{self.leadTime}:"
+                f"{self.duration} {self.statisticalProcess.definition}"
+            )
+
+        return (
+            f"{prefix} ({self.units}):{self.level}:"
+            f"{self.leadTime}"
+        )
 
     def _generate_signature(self):
         """Generature SHA-1 hash string from GRIB2 integer sections."""

--- a/src/grib2io/_grib2io.py
+++ b/src/grib2io/_grib2io.py
@@ -1066,35 +1066,19 @@ class _Grib2Message:
             selected attributes.
         """
         pdtn = self.pdtn
-        prefix = (
-            f"{self._msgnum}:d={self.refDate}:"
-            f"{self.shortName}:{self.fullName}"
-        )
+        prefix = f"{self._msgnum}:d={self.refDate}:{self.shortName}:{self.fullName}"
 
         if pdtn in {5, 9}:
-            return (
-                f"{prefix} (%):{self.level}:{self.leadTime}:"
-                f"{self.duration}:{self.threshold} "
-                f"({self.parameterUnits})"
-            )
+            return f"{prefix} (%):{self.level}:{self.leadTime}:{self.duration}:{self.threshold} ({self.parameterUnits})"
 
         if pdtn in {6, 10}:
             percentile = utils.percentile_string(self.percentileValue)
-            return (
-                f"{prefix} ({self.units}):{self.level}:{self.leadTime}:"
-                f"{self.duration}:{percentile}"
-            )
+            return f"{prefix} ({self.units}):{self.level}:{self.leadTime}:{self.duration}:{percentile}"
 
         if pdtn == 8:
-            return (
-                f"{prefix} ({self.units}):{self.level}:{self.leadTime}:"
-                f"{self.duration} {self.statisticalProcess.definition}"
-            )
+            return f"{prefix} ({self.units}):{self.level}:{self.leadTime}:{self.duration} {self.statisticalProcess.definition}"
 
-        return (
-            f"{prefix} ({self.units}):{self.level}:"
-            f"{self.leadTime}"
-        )
+        return f"{prefix} ({self.units}):{self.level}:{self.leadTime}"
 
     def _generate_signature(self):
         """Generature SHA-1 hash string from GRIB2 integer sections."""

--- a/src/grib2io/templates.py
+++ b/src/grib2io/templates.py
@@ -1330,6 +1330,18 @@ class ParameterNumber:
         obj.section4[self._key[obj.pdtn] + 2] = value
 
 
+class ParameterUnits:
+    """Native units as described by the GRIB2 Discipline, Parameter Category, and Parameter Number"""
+
+    def __get__(self, obj, objtype=None):
+        return tables.get_varinfo_from_table(obj.section0[2], *obj.section4[2:4], isNDFD=obj._isNDFD)[1]
+
+    def __set__(self, obj, value):
+        raise RuntimeError(
+            "Cannot set the units of the message.  Instead set shortName OR set the appropriate discipline, parameterCategory, and parameterNumber.  The units will be set automatically from these other attributes."
+        )
+
+
 class VarInfo:
     """
     Variable Information.
@@ -1395,7 +1407,7 @@ class Units:
     """Units of the Variable."""
 
     def __get__(self, obj, objtype=None):
-        return tables.get_varinfo_from_table(obj.section0[2], *obj.section4[2:4], isNDFD=obj._isNDFD)[1]
+        return obj.parameterUnits if obj.pdtn not in {5, 9} else "%"
 
     def __set__(self, obj, value):
         raise RuntimeError(
@@ -2912,6 +2924,7 @@ class ProductDefinitionTemplateBase:
     # Begin template here...
     parameterCategory: int = field(init=False, repr=False, default=ParameterCategory())
     parameterNumber: int = field(init=False, repr=False, default=ParameterNumber())
+    parameterUnits: int = field(init=False, repr=False, default=ParameterUnits())
     typeOfGeneratingProcess: Grib2Metadata = field(init=False, repr=False, default=TypeOfGeneratingProcess())
     generatingProcess: Grib2Metadata = field(init=False, repr=False, default=GeneratingProcess())
     backgroundGeneratingProcessIdentifier: int = field(init=False, repr=False, default=BackgroundGeneratingProcessIdentifier())

--- a/src/grib2io/utils/__init__.py
+++ b/src/grib2io/utils/__init__.py
@@ -408,3 +408,43 @@ def compute_with_retries(obj, *, max_attempts: int = 6, base_sleep: float = 2.0)
             sleep_s = base_sleep**attempt
             print(f"Transient read error ({type(exc).__name__}) on attempt {attempt}/{max_attempts}; retrying in {sleep_s}s...")
             time.sleep(sleep_s)
+
+
+def percentile_string(pct):
+    """
+    Return a percentile string with the proper English ordinal suffix.
+
+    Parameters
+    ----------
+    pct : int
+        Percentile value in the range [0, 100].
+
+    Returns
+    -------
+    str
+        Percentile string, e.g., ``"1st percentile"``,
+        ``"21st percentile"``, or ``"90th percentile"``.
+
+    Raises
+    ------
+    ValueError
+        If `pct` is not in the range [0, 100].
+
+    Examples
+    --------
+    >>> percentile_string(1)
+    '1st percentile'
+    >>> percentile_string(21)
+    '21st percentile'
+    >>> percentile_string(90)
+    '90th percentile'
+    """
+    if not (0 <= pct <= 100):
+        raise ValueError("percentile must be between 0 and 100")
+
+    if 11 <= (pct % 100) <= 13:
+        suffix = "th"
+    else:
+        suffix = {1: "st", 2: "nd", 3: "rd"}.get(pct % 10, "th")
+
+    return f"{pct}{suffix} percentile"


### PR DESCRIPTION
Changes:

* Introduce a new `Grib2Message` attribute, `parameterUnits`, which provides the units of the "native" parameter as specified in the GRIB2 tables.
* `Grib2Message.units` will now provide transformed units as dictated by the product definition template.  For example, temperature probability of exceedance will now be units of `"%"`
* Updated `Grib2Message.__str__()` to provide more information when necessary -- percentiles, thresholds, etc.